### PR TITLE
added model testing notebook

### DIFF
--- a/notebooks/prometheus_anomaly_detection_test.ipynb
+++ b/notebooks/prometheus_anomaly_detection_test.ipynb
@@ -1,0 +1,863 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test Driven Data Science for Prometheus Anomaly Detector\n",
+    "\n",
+    "The below notebook represents an initial prototype for testing the performance of new models on historical data prior to live deployment.\n",
+    "\n",
+    "As the aim of this project is to serve as a framework to deploy metric prediction models to detect anomalies in prometheus metrics, we would like to develop a 'testing mode' for the anomaly detector so that we can clearly evaluate the performance of our models prior to deploying them.\n",
+    "\n",
+    "For this initial prototype we will implement a somewhat naive approach and auto-label all of the data as anomalous/not anomalous based on a static threshold set by the user. Although this method is inherently problematic (seasonality will be ignored, for example) we are aware of its limitations and it will serve only as a guide. If we had an error-free method of auto-labeling anomalies, we would have our ML model and no more testing would be required. That said, this prototype could be easily modified with a more sophisticated auto-labeling method.\n",
+    "\n",
+    "Once the data has been naively auto-labeled, we simulate 24 hours of running the tool, where every hour we train a prophet model on the last week of data and forecast out one hour. We compute the true positive rate for each hour segment, as well as for the entire 24 hour period between our auto-labeled \"ground truth\" anomalies and the anomalies found by the detector (i.e., if they exceed the upper or lower bounds of the prediction). That said, the inclusion of additional performance metrics, more sophisticated auto-labeling procedures or manual anomaly labeling may improve this testers ability to evaluate models. This is an initial POC.       \n",
+    "\n",
+    "This test will require the following configurations:\n",
+    "\n",
+    " - query range\n",
+    " - training window\n",
+    " - metric name\n",
+    " - label_config\n",
+    " - prom url \n",
+    " - prom token\n",
+    " - threshold\n",
+    "\n",
+    "\n",
+    "Finally, the user of this test should already have zeroed in on the specific anomalous time frame and metric value they want to test and can provide the entire label_config.\n",
+    "\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os \n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import prometheus_api_client as prom_api\n",
+    "from prometheus_api_client import Metric, MetricsList, PrometheusConnect\n",
+    "import matplotlib.pyplot as plt \n",
+    "import time\n",
+    "from fbprophet import Prophet\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "%matplotlib inline\n",
+    "%load_ext dotenv\n",
+    "%dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will require the following configurations.\n",
+    "\n",
+    "# - query range\n",
+    "# - training window\n",
+    "# - metric name\n",
+    "# - label_config\n",
+    "# - prom url \n",
+    "# - prom token\n",
+    "# - threshold\n",
+    "\n",
+    "# The user of this test should already have zeroed in on the specific timeframe and metric value they want to test\n",
+    "# and can provide the entire label_config.\n",
+    "\n",
+    "\n",
+    "def prometheus_anoamly_test(query_range, training_window, metric_name, label_config, prom_url, prom_token, threshold):\n",
+    "    \n",
+    "\n",
+    "    # Read data into memory and convert to a Metric list Object\n",
+    "    \n",
+    "    prom = prom_api.prometheus_connect.PrometheusConnect(url=prom_url, headers={\"Authorization\": \"bearer {}\".format(prom_token)}, \n",
+    "                                                     disable_ssl=True)\n",
+    "    \n",
+    "    metric_data = prom.get_metric_range_data(metric_name=metric_name,\n",
+    "                                         start_time=query_range[1],\n",
+    "                                         end_time=query_range[0],\n",
+    "                                         label_config=label_config)\n",
+    "    \n",
+    "    metrics = MetricsList(metric_data)\n",
+    "    m = metrics[0]\n",
+    "    \n",
+    "    num_true_positive = 0\n",
+    "    num_groud_truth = 0\n",
+    "    \n",
+    "    # simulate 24 hours of training and forecasting out one hour to test model.  \n",
+    "    for i in range(24):\n",
+    "        \n",
+    "        # create new df with labels on a metric signal based on simple threshold method. \n",
+    "        labeled_metric = simple_metric_labeler(m.metric_values, threshold)\n",
+    "        _ , ground_truth = timeseries_train_test_split(labeled_metric, training_window, i)\n",
+    "\n",
+    "        # Split data into train test\n",
+    "\n",
+    "        train, test = timeseries_train_test_split(m.metric_values, training_window, i)\n",
+    "\n",
+    "        # Train model based on training window\n",
+    "\n",
+    "        model = train_prophet(train)\n",
+    "\n",
+    "        # Forecast 1 hour into the future\n",
+    "\n",
+    "        forecast = predict_prophet(model, test)\n",
+    "        \n",
+    "        # Count number of anomalies detected by forecast\n",
+    "\n",
+    "        forecasted_anomalies = forecast_anomalies(forecast, test)\n",
+    "\n",
+    "        # Compute true positive rate and report ground truth and prediction values\n",
+    "        \n",
+    "        print(\"ground truth anomlies\", sum(ground_truth.label.values))\n",
+    "        print(\"forecast anomalies\", sum(forecasted_anomalies.label.values))\n",
+    "        print(\"number of data points\", len(test.label.values))\n",
+    "        \n",
+    "        true_postive_rate = compute_true_positive_rate(forecasted_anomalies,ground_truth)\n",
+    "        print(\"true positive rate\", true_postive_rate)\n",
+    "        \n",
+    "        num_true_positive += count_true_positives(forecasted_anomalies,ground_truth)\n",
+    "        num_groud_truth += sum(ground_truth.label.values)\n",
+    "        \n",
+    "             \n",
+    "    # compute and return the overall true positive rate \n",
+    "    total_true_positive_rate = num_true_positive/num_groud_truth\n",
+    "    \n",
+    "    return total_true_positive_rate\n",
+    "\n",
+    "\n",
+    "def simple_metric_labeler(signal_df, threshold):\n",
+    "    labeld_df = signal_df\n",
+    "    label_column = (signal_df[\"y\"] >= threshold).values.astype(int) \n",
+    "    labeld_df[\"label\"] = label_column\n",
+    "    return labeld_df\n",
+    "\n",
+    "def train_prophet(data):\n",
+    "    model = Prophet()\n",
+    "    model.fit(data)\n",
+    "    return model\n",
+    "\n",
+    "def predict_prophet(model, future_time):\n",
+    "    forecast = model.predict(future_time)\n",
+    "    return forecast[['ds', 'yhat', 'yhat_lower', 'yhat_upper']]\n",
+    "\n",
+    "def timeseries_train_test_split(df, training_window, hour):\n",
+    "    \n",
+    "    earliest_time = df[\"ds\"].iloc[0] + pd.Timedelta(hour * 3600, 'sec')\n",
+    "    seconds_training_window = training_window * 604800 # convert to seconds from weeks\n",
+    "    training_window_end = earliest_time + pd.Timedelta(seconds_training_window, 'sec')\n",
+    "    test_window_end = training_window_end + pd.Timedelta(3600, 'sec') # add an hour imeseries_train_test_split(df, t\n",
+    "    \n",
+    "    train = df[df['ds'] <= training_window_end]\n",
+    "    test = df[df['ds'] > training_window_end]\n",
+    "    test = test[test['ds'] < test_window_end]\n",
+    "    \n",
+    "    print(training_window_end, \"training window end\")\n",
+    "    print(test_window_end, \"test window end\")\n",
+    "    \n",
+    "    return train, test\n",
+    "\n",
+    "def forecast_anomalies(forecast_df, signal_df):\n",
+    "    detections = []\n",
+    "    for y, yhat_upper, yhat_lower in zip(signal_df.y,forecast_df.yhat_upper, forecast_df.yhat_lower):\n",
+    "        \n",
+    "        if y <= yhat_lower:\n",
+    "            detections.append(1)\n",
+    "        \n",
+    "        elif y >= yhat_upper:\n",
+    "            detections.append(1)\n",
+    "        \n",
+    "        else:\n",
+    "            detections.append(0)\n",
+    "    \n",
+    "    detected_df = forecast_df\n",
+    "    detected_df[\"label\"] = detections\n",
+    "    return detected_df    \n",
+    "\n",
+    "def compute_true_positive_rate(forecasted_anomalies, labeled_anomalies):\n",
+    "    \n",
+    "    num_true_positive = count_true_positives(forecasted_anomalies, labeled_anomalies)\n",
+    "    true_postive_rate = num_true_positive/sum(labeled_anomalies.label.values)\n",
+    "    \n",
+    "    return true_postive_rate\n",
+    "\n",
+    "def count_true_positives(forecast_anomalies, labeled_anomalies):\n",
+    "        \n",
+    "        num_true_positive = sum((forecast_anomalies.label.values == 1) & \n",
+    "                            (labeled_anomalies.label.values == 1))\n",
+    "        \n",
+    "        return num_true_positive\n",
+    "\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# example configurations\n",
+    "metric_name=\"name\"\n",
+    "query_range = ('end_time','start_time') \n",
+    "label_config={}\n",
+    "\n",
+    "prom_url = 'prometheus route'\n",
+    "prom_token = 'prometheus access token'\n",
+    "training_window='integer representing weeks'\n",
+    "threshold = 'float'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABI0AAAI/CAYAAAD6GilwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAgAElEQVR4nOzde7hcZXk3/vshgQQQECP6IqkmVkQxnCSAlkNFEGlRsVWESmvV9qK1hVptrfG9RFMqFVqq1kPlpR6w/FQQkRoaFIsQOQcSCHKGBAJsAuRAEnLayT6s3x/ZiTt79mFmz2HNrPX5XFeuzKxZs+aetWfPXvOd+3lWyrIsAAAAAGCwnfIuAAAAAID2IzQCAAAAoILQCAAAAIAKQiMAAAAAKgiNAAAAAKggNAIAAACgwsS8C6jFy1/+8mzatGl5lwEAAABQGAsXLlyZZdk+Q5d3VGg0bdq0WLBgQd5lAAAAABRGSunJ4ZYbngYAAABABaERAAAAABWERgAAAABU6Kg5jYbT09MTXV1d0d3dnXcppTJ58uSYOnVq7LzzznmXAgAAADRBx4dGXV1dsccee8S0adMipZR3OaWQZVmsWrUqurq6Yvr06XmXAwAAADRBxw9P6+7ujilTpgiMWiilFFOmTNHdBQAAAAXW8aFRRAiMcmCfAwAAQLEVIjQCAAAAoLGERjlbtGhRXHvttSPevmDBgvibv/mbuh7j0ksvjbPPPnvUdebNmxe33XZbXY8DAAAAFIfQKGejhUa9vb0xc+bM+OpXv9r0OoRGAAAAwGBCowZYunRpvOENb4g///M/jxkzZsSZZ54Z119/fRx99NGx//77x5133hkbNmyIj370o3HEEUfEYYcdFj/96U9jy5Yt8bnPfS6uuOKKOPTQQ+OKK66I2bNnx1lnnRUnnXRSfOhDH4p58+bFu971roiIWL9+fXzkIx+Jgw46KA4++OC46qqrRqzpu9/9brz+9a+P3/3d341bb711+/JrrrkmjjrqqDjssMPixBNPjOeffz6WLl0aF198cXz5y1+OQw89NG6++eZYsWJFvO9974sjjjgijjjiiB22AQAAABTfxLwLaKR/vOaBeHDZiw3d5oGv2jM+/+43jbne4sWL48orr4xLLrkkjjjiiPjBD34Qt9xyS8yZMyf++Z//OQ488MB4+9vfHt/5zndizZo1ceSRR8aJJ54Y5513XixYsCC+/vWvR0TE7NmzY+HChXHLLbfErrvuGvPmzdv+GP/0T/8Ue+21V9x3330REbF69epha3n22Wfj85//fCxcuDD22muvOP744+Owww6LiIhjjjkm7rjjjkgpxbe+9a34l3/5l/i3f/u3+Mu//Mt4yUteEn//938fEREf/OAH4xOf+EQcc8wx8dRTT8U73/nOeOihh+rZlQAAAEAHKVRolKfp06fHQQcdFBERb3rTm+KEE06IlFIcdNBBsXTp0ujq6oo5c+bERRddFBER3d3d8dRTTw27rfe85z2x6667Viy//vrr4/LLL99+fe+99x72/vPnz4+3ve1tsc8++0RExOmnnx6PPvpoRER0dXXF6aefHs8++2xs2bIlpk+fPuw2rr/++njwwQe3X3/xxRdj3bp1sccee4y1KwAAAIACKFRoVE1HULNMmjRp++Wddtpp+/Wddtopent7Y8KECXHVVVfFAQccsMP95s+fX7Gt3XfffdjHyLKs6lPdj7TeOeecE5/85CfjPe95T8ybNy9mz5497Hr9/f1x++23DxteAQAAAMVnTqMWeec73xlf+9rXIsuyiIi45557IiJijz32iHXr1lW1jZNOOmn7MLaIkYenHXXUUTFv3rxYtWpV9PT0xJVXXrn9trVr18Z+++0XERHf+973ti8fWsfQx1q0aFFVNQIAAADFIDRqkXPPPTd6enri4IMPjhkzZsS5554bERHHH398PPjgg9snwh7NZz/72Vi9enXMmDEjDjnkkLjxxhuHXW/fffeN2bNnx1vf+tY48cQT481vfvP222bPnh2nnXZaHHvssfHyl798+/J3v/vdcfXVV2+fCPurX/1qLFiwIA4++OA48MAD4+KLL27AXgAAAAA6RdrW+dIJZs6cmS1YsGCHZQ899FC88Y1vzKmicrPvAQAAoPOllBZmWTZz6HKdRgAAAABUKNRE2GV01FFHxebNm3dYdtlll20/kxsAAADAeAiNOtxwZ18DAAAAqJfhaQAAAABUEBoBAAAAUEFoBAAAAHSEv/r+wrjm3mV5l1EaQqM6rVmzJv7jP/4jIiLmzZsX73rXuxr+GJdeemmcffbZNd1n2rRpsXLlyorls2fPjosuuqhRpQEAAEDLXHvfc3HOD+/Ju4zSEBrVaXBoVK2+vr4mVQMAAADQGEKjOs2aNSuWLFkShx56aHzqU5+K9evXx/vf//54wxveEGeeeWZkWRYRWzt/zjvvvDjmmGPiyiuvjCVLlsTJJ58chx9+eBx77LHx8MMPR0TElVdeGTNmzIhDDjkkjjvuuO2Ps2zZsjj55JNj//33j3/4h3/YvvyHP/xhHHTQQTFjxoz49Kc/PWyN559/fhxwwAFx4oknxiOPPNLEvQEAAAAUxcS8C+h0F1xwQdx///2xaNGimDdvXpx66qnxwAMPxKte9ao4+uij49Zbb41jjjkmIiImT54ct9xyS0REnHDCCXHxxRfH/vvvH/Pnz4+/+qu/ihtuuCHOO++8uO6662K//faLNWvWbH+cRYsWxT333BOTJk2KAw44IM4555yYMGFCfPrTn46FCxfG3nvvHSeddFL893//d7z3ve/dfr+FCxfG5ZdfHvfcc0/09vbGm9/85jj88MNbu5MAAACAjlOs0Ohv/zZi0aLGbvPQQyO+8pWqVz/yyCNj6tSpA3c9NJYuXbo9NDr99NMjImL9+vVx2223xWmnnbb9fps3b46IiKOPPjo+/OEPxwc+8IH4wz/8w+23n3DCCbHXXntFRMSBBx4YTz75ZKxatSre9ra3xT777BMREWeeeWbcdNNNO4RGN998c/zBH/xB7LbbbhER8Z73vKfmXQAAAACUT7FCozYwadKk7ZcnTJgQvb2926/vvvvuERHR398fL33pS2PRMAHXxRdfHPPnz4+5c+fGoYceun2d4ba7bejbWFJK43ouAAAAQHkVKzSqoSOoUfbYY49Yt25dTffZc889Y/r06XHllVfGaaedFlmWxa9//es45JBDYsmSJXHUUUfFUUcdFddcc008/fTTI27nqKOOio9//OOxcuXK2HvvveOHP/xhnHPOOTusc9xxx8WHP/zhmDVrVvT29sY111wTf/EXfzGu5woAAACUR7FCoxxMmTIljj766JgxY0bsuuuu8cpXvrKq+33/+9+Pj33sY/GFL3whenp64owzzohDDjkkPvWpT8Vjjz0WWZbFCSecEIcccsiwHUkREfvuu2988YtfjOOPPz6yLIvf//3fj1NPPXWHdd785jfH6aefHoceemi85jWviWOPPbbu5wwAAAAUX6p2iFM7mDlzZrZgwYIdlj300EPxxje+MaeKys2+BwAAoJWmzZobERFLLzgl50qKJaW0MMuymUOX75RHMQAAAAC0N6ERAAAAABWERgAAAABUKERo1EnzMhWFfQ4AAADF1vGh0eTJk2PVqlVCjBbKsixWrVoVkydPzrsUAAAAoEkm5l1AvaZOnRpdXV2xYsWKvEsplcmTJ8fUqVPzLgMAAABoko4PjXbeeeeYPn163mUAAAAAFErHD08DAAAAoPGERgAAAABUEBoBAAAAUEFoBAAAAEAFoREAAAAAFYRGAAAAAFQQGgEAAABQQWgEAAAAQAWhEQAAAAAVhEYAAAAAVBAaAQAAAFBBaAQAAABABaERAAAAABWERgAAAABUEBoBAAAAUEFoBAAAAEAFoREAAAAAFYRGAAAAAFQQGgEAAABQQWgEAAAAQAWhEQAAAAAVhEYAAAAAVBAaAQAAAFBBaAQAAABABaERAAAAABWERgAAAABUEBoBAAAAUEFoBAAAAEAFoREAAAC0ucvvfCquuXdZ3mVQMhPzLgAAAAAY3ayf3BcREe8+5FU5V0KZ6DQCAAAAoILQCAAAAIAKQiMAAAAAKgiNAAAAAKggNAIAAACggtAIAAAAgApCIwAAAAAqCI0AAACAQljX3RPTZs2NXzzwXN6lFILQCAAAACiEx1dsiIiIr9+4OOdKikFoBAAAAEAFoREAAAAAFYRGAAAAAFQQGgEAAABQQWgEAAAAQAWhEQAAAFAIWd4FFIzQCAAAACiUlHcBBSE0AgAAAKCC0AgAAACACkIjAAAAACoIjQAAAACoIDQCAAAACiHLnD+tkYRGAAAAAFQQGgEAAACFkFLKu4RCERoBAAAAUEFoBAAAAEAFoREAAAAAFaoKjVJKJ6eUHkkpLU4pzRrm9kkppSsGbp+fUpo2sPwdKaWFKaX7Bv5/+6D7HD6wfHFK6avJwEMAAACAtjFmaJRSmhAR34iI34uIAyPij1JKBw5Z7c8iYnWWZa+LiC9HxIUDy1dGxLuzLDsoIv40Ii4bdJ9vRsRZEbH/wL+T63geAAAAQMllWZZ3CYVSTafRkRGxOMuyx7Ms2xIRl0fEqUPWOTUivjdw+ccRcUJKKWVZdk+WZcsGlj8QEZMHupL2jYg9syy7Pdv6E/2viHhv3c8GAAAAwGCmhqgmNNovIp4edL1rYNmw62RZ1hsRayNiypB13hcR92RZtnlg/a4xtgkAAABATiZWsc5w8dzQfq9R10kpvSm2Dlk7qYZtbrvvWbF1GFu8+tWvHqtWAAAAABqgmk6jroj4rUHXp0bEspHWSSlNjIi9IuKFgetTI+LqiPhQlmVLBq0/dYxtRkRElmWXZFk2M8uymfvss08V5QIAAABQr2pCo7siYv+U0vSU0i4RcUZEzBmyzpzYOtF1RMT7I+KGLMuylNJLI2JuRHwmy7Jbt62cZdmzEbEupfSWgbOmfSgiflrncwEAAACgQcYMjQbmKDo7Iq6LiIci4kdZlj2QUjovpfSegdW+HRFTUkqLI+KTETFrYPnZEfG6iDg3pbRo4N8rBm77WER8KyIWR8SSiPhZo54UAAAAUD7OndZY1cxpFFmWXRsR1w5Z9rlBl7sj4rRh7veFiPjCCNtcEBEzaikWAAAAgNaoZngaAAAAQNsb7qxbjJ/QCAAAAIAKQiMAAAAAKgiNAAAAAKggNAIAAACggtAIAAAAKIQs7wIKRmgEAAAAFIqzqDWG0AgAAACACkIjAAAACm1dd09s7u3LuwzoOEIjAAAACu2g2b+ID/y/O/IuAzqO0AgAAIDCu/fpNXmXAB1HaAQAAAAUQub0aQ0lNAIAAAAKJY1x+rSu1RvjoNnXxeMr1remoA4lNAIAAAAKZayOo2vufTbWdffGFQuebk1BHUpoBAAAABTCWB1G1EZoBAAAAEAFoREAAAAAFYRGAAAAUFBPv7Axps2aGwuWvpB3KXQgoREAAAAU1C2LV0ZExI8XduVcSWuMNQE2tREaAQAAAIVS9YTYQqZRCY0AAACAUnGWteoIjQAAAKDgDNtiPIRGAAAAUFAaaqiH0AgAAAAoFZ1X1REaAQAAQE6WrdkUy9ZsyruMAqkxDdKKNaqJeRcAAAAAZfU7F9wQERFLLzilqY+Tlew0YbKgxtBpBAAAAAVV1rOEVR2RlStLq5nQCAAAACiI6lKysoZptRIaAQAAAFBBaAQAAAAF52xhjIfQCAAAAAoqmRKaOgiNAAAAoKDKdtY0M1s3ltAIAAAACq5sEz+X7Ok2jdAIAAAACs6cRoyH0AgAAAAKypxG1ENoBAAAAOPwk7u7YtqsubF2U0/epUBTCI0AAABgHL518xMREfH0CxtzrgSaQ2gEAAAABVeWKY3M3dRYQiMAAAAoqpJOaZTKdrq4JhEaAQAAAFBBaAQAAAAFV7ZhW1mVT7hku6VmQiMAAAAoqLIN0qp2VFrZ9st4CY0AAABgHEybQ9EJjQAAAGAcyjbki/IRGgEAAEDBZSWZvafaIK8ce6N+QiMAAACgUFKVYweNMByd0AgAAAAKLolHGAehEQAAAFBKhqmNTmgEAAAABVeWOY2qpe+qOkIjAAAAGIdqps3Z3NsX02bNjR8teLr5BQ2j2rl9YDhCIwAAAGiStRt7IiLiX697JOdKykE/VWMJjQAAAIBC0V/VGEIjAAAAGIesk9paOqlW2obQCAAAAAqqyB03WZZFNkJyJyNrDKERAAAANMiL3T07XO/tF180y/TPXBunX3LHDsuKHJLlQWgEAAAA4zD0xGT3da2Ng2f/Iq65d9n2Zf/36vsiImJzT18rSyuNO594Ie8SCk1oBAAAAA1w/7K1ERFx6+KV25fNe2RFRET09OXbcVSWfqeyPM9WERoBAABAkw3tSir64+atpE+74YRGAAAAQEd5+LkX8y6hFIRGAAAAUFAjnFys4538lZvzLqEUhEYAAAAUyp9+586Y+YX/zbWG5eu649Hn19V0n2fXbor1m3ubVBHUbmLeBQAAAEAj/erRFXmXEL/zxRuit/83bT7VdPy89Ys3xOte8ZK4/pO/27A6yjqnUbWyorZiNYhOIwAAAGiwwYFRLRYvX9/gShiOMK06QiMAAACgEDQONZbQCAAAAJos786Wsg3DGmt/l2x3jJvQCAAAABqgHYOIvMOqdpfsoFEJjQAAAKCB5BAUhdAIAAAA6lBNh1E7diEVmf3dGEIjAAAAKLiyZCi1dnmVba6nWgmNAAAAoA5Dg4p2yiFSlGusXLX73hDC6giNAAAAoAEaGUQsX9cd35y3RCfMOAmFGkNoBAAAADmbNmvuDtc//sNFceHPH44Hlr3YkO3LnhgPoREAAAA0Wa2dLxu29EZERF9/fWmPjhvqITQCAACAOrTz2dN0GFEPoREAAACMQztPgD2UjiPGQ2gEAAAADdSOAU07B1q0L6ERAAAAjEMzg5hGbbsdA6xmcra5xhIaAQAAwBA9ff1x06Mrqlq3mcFM2UKfRklhxzWC0AgAAACG+Mr1j8aHvnNn3PH4qrxLgdwIjQAAAGCIJ1ZuiIiIVeu3jLluJ4yI6oASaUNCIwAAABgHQ8coOqERAAAAUCiZ3qqGEBoBAABAA3XCcDW28rMandAIAAAAhhhPmDDacLW8h7KV7VT0Y509zdnVqiM0AgAAgBGMFvYMzWHaMZdJeadVdDShEQAAADSQnKb9mfOoOkIjAAAAGIdawqF27EJCwDcWoREAAAC0GZ0wtAOhEQAAAIwg7w4hEzaTp4l5FwAAAABQj2fXbopdd55Qc39W3qFgu9NpBAAAACMw501neOsXb4jfueCG3ywY4+emg6s6QiMAAABosrznKCpDQ83GLX15l1A4QiMAAAAYpGv1xvjZ/c9VvX7egdBo9NNQD6ERAAAADHLbklUN36bhUHQioREAAADUYVsg1M4dR0XWtXpj5UI/ioYQGgEAAMAIxtcf1IZdRQUOUY658Maa7yPgq05VoVFK6eSU0iMppcUppVnD3D4ppXTFwO3zU0rTBpZPSSndmFJan1L6+pD7zBvY5qKBf69oxBMCAACAfLVPIFHas7+V9Xk32MSxVkgpTYiIb0TEOyKiKyLuSinNybLswUGr/VlErM6y7HUppTMi4sKIOD0iuiPi3IiYMfBvqDOzLFtQ53MAAACAhhlv3mDeos7hZ1WdajqNjoyIxVmWPZ5l2ZaIuDwiTh2yzqkR8b2Byz+OiBNSSinLsg1Zlt0SW8MjAAAAKJxmDHXK2qdZiRKrJjTaLyKeHnS9a2DZsOtkWdYbEWsjYkoV2/7uwNC0c1MqbdMcAAAAbWq07KYV3SqN+qRsDh/Go5rQaLiX6NBXWzXrDHVmlmUHRcSxA//+ZNgHT+mslNKClNKCFStWjFksAAAAtBttEu1jw+beOP/ah/IuoyNUExp1RcRvDbo+NSKWjbROSmliROwVES+MttEsy54Z+H9dRPwgtg6DG269S7Ism5ll2cx99tmninIBAACgMUbLemrp3mn2cLOnVm2MLb39I95uDp/f+N8Hn8+7hI5RTWh0V0Tsn1KanlLaJSLOiIg5Q9aZExF/OnD5/RFxQ5aN/CuRUpqYUnr5wOWdI+JdEXF/rcUDAABA3vIOZNZs3BLH/euN8fk5I3+sLsvwNHNBNdaYZ0/Lsqw3pXR2RFwXERMi4jtZlj2QUjovIhZkWTYnIr4dEZellBbH1g6jM7bdP6W0NCL2jIhdUkrvjYiTIuLJiLhuIDCaEBHXR8R/NvSZAQAAQAuNFsw0M7RZ190bERE3P7ay4ra8A628jPas//aKRdsvb+nrj18+9Hyc8MZXNr+oDjRmaBQRkWXZtRFx7ZBlnxt0uTsiThvhvtNG2Ozh1ZUIAAAA7asyEKo/qKmmY+a2JSvjJZMmxt677VL345XVf93+ZPzX7U/GFWe9JY56bTXn8yqXqkIjAAAAKItqT+6ddxfPB/9zfkRE3PwPx+daRxGs3tiTdwltqZo5jQAAAIAWGs/Z1kbrTjLXD+MhNAIAAIARjCe8GXY7OXUlNap+ykloBAAAAEAFoREAAACMYNQhXyOeEa3+sWDjGU6mqyiiu6cv7xIKRWgEAAAAVVo7yoTJ24ag/fDOp1tVzg7MaRTxkUvvyruEQhEaAQAAQBUeWLY2DjnvF3HVwq6IyP/sadVo/wrbRUlStRoJjQAAAGAEg4d8PfLcuoiIuGXxypyqgdYSGgEAAEADjDzHEXQmoREAAAAM0owhXSapphMJjQAAAKAKrZxMWs8S7UBoBAAAADUYT9NQWc5e1i50djWG0AgAAABqMJ78p9b5jmQetAOhEQAAAIzoN/FNu3avVFOXSboZD6ERAAAAVKETh5i1a9BFZxAaAQAAwIgqk6JW5DC15FOdGGbRGYRGAAAAUKOFT74Q9z2ztur10zijJp1C5EloBAAAAIOMFNQMbui5/qHlNW2zmXMKVTWnkW4kxkFoBAAAQCE99vy6+MDFt9e5lWESmSGL2juQ0arE+AmNAAAAKKQvzH0o7lz6QuM3PI6QaPDwtE1b+mLarLnxo7uebmBR0HhCIwAAAKhCo3p2lq/rjoiIr9+4uEFbhOYQGgEAAEAVRmowasZk1VmDx7y19Qi6NtDeQwzzIzQCAACAWqTOCRmcfa163T190dPXv/36w8+9GLc8tjLHivInNAIAAIA2kxqU9nRKuNUO3nDuz+PdX7tl+/WTv3Jz/PG35+dYUf6ERgAAADCCkbKbwcvbJZgZbUhb2RqO0jif8cPPrWtwJZ1NaAQAAACDjNXks6W3P745b0lN29zU0xdLVqzfYVnWoJmGqulKapNciw4jNAIAAKCQGjHCa7jmnXueWlOx7L6utdE/RjLziSsWba2rii6YWibCHrzuI8+ti58uemb7dXMaUY+JeRcAAAAAnWzBk6vjn/7nwdjvpbs2fNu1DLNKKcU7v3JTRESceuh+Da+lk/T294+90iBPvbBxh+vTZs1tZDkdS6cRAAAAhXT/M2sbur1tHT1Du3eWrdkUERHPDPyfl9G6k9pl3qVWuWvp6h2uf+g7d8Y5P7xnxPW/+LOHm11SRxIaAQAAUEgr12+pexvVDO+qthdo23q1zGV03zOVQ+EqtjtKkUUYnbZq/eb4yHfvjDUbx//zvOnRFXHNvcsaWFU5CI0AAABgBKvWb4nFy1t7Rq35j6/afvnTV93X0sduR9+65Ym48ZEV8f35T+VdSumY0wgAAIDC6OkbeS6bLMuqOtPYYP/36q2hzdILTqmrrsHGmqfo9EvuaNhjQT10GgEAAFAYfaOcwuzFTb1Necxqc6h7u9bGd299oik1jK1kkxrREEIjAAAAGKSWM5bV6h+vebBp2162trtiWa2dVTCY0AgAAIDCKNtZwiIizrjk9rxLKJQbH16edwltQ2gEAABAOTSp6Wa83TyNCriefmFTYzbU5lo1tO8jl97VksfpBEIjAAAACqOZo7G2ZTz1PkYeI8aK0IG1cv2WvEsoHaERAAAApWB6H6iN0AgAAIDCaGZHTaMypzy6fgRmjIfQCAAAgFJoVm4y3u0Kcmh3QiMAAAAKoxVzGnWiIsxpROsJjQAAACiMRoQjYwVPaUhv0brNveN6nFYEOZqZqIfQCAAAAOrwg/lP1bS+YWl0CqERAAAApZCkNVAToREAAACFIRcanimNGA+hEQAAAIUx2jxBZcyThGg7+saNi/MuoaMIjQAAACAHXas35V1C6fzrdY/kXUJHERoBAABQCnV33WQN2g50CKERAAAAFFw22rg9GIHQCAAAAGrQ6kajabPmVix7atXGqu6rK4p6CI0AAACgBnn37Nz91Oo47l9vzLkKykBoBAAAAB3k8RUbql7XqDTqITQCAACgMLIW9AEZ8UVZCI0AAACgoMo8p9H6zb15l9DxhEYAAABA4cz4/HXR3298Xj2ERgAAABRGM+fwacXQt2bp3Mrrs7GnL+8SOprQCAAAgFIo46TQyQxM1EFoBAAAAIOkESYCapcAJitj+kUuhEYAAABQhW3D00YKlVqhp68/PvXjX+f2+JSL0AgAAIDCKHoPzpqNPeO6n+YkxkNoBAAAADVoj0FqVeqoYmk3QiMAAACowZMvbMy7BKokM6uP0AgAAIDCaMUk0X39+Y316jfOrCb2Vn2ERgAAANBC9cyj/d5v3Dqu+wlPGA+hEQAAAKVQhODk2bXdNa1veBb1EBoBAADAIEUKWooQlJEfoREAAACF0cyQpFHTCeUxLVGRgrBalPV5N8rEvAsAAAAAmqusHUc3Pboidp8k+hgvew4AAACqsLm3P+8Salb2TpuPff/uvEvoaIanAQAAUBjNHPr1+TkPNGQ79Zw9rYxueGh53iWUltAIAAAAaFuPPL8u7xJKS2gEAAAAY+jp67yhaYNlecy+TccTGgEAAFAK9QQn5899qIGVtE4yFo46CI0AAAAojgY01AyXs9z3zNr6NwwdRmgEAAAAY1j45OqGbUv3D51CaAQAAAAtZH4hOoXQCAAAgMLIGjE+rcm29LZuUm09TdRDaAQAAAAtdMKXfpV3CVAVoREAAAC0kNFpdIqJeRcAAAAAjVJPIPOTu5lrM24AACAASURBVLviVS/dtXHF5Gj5i93xij0n510GHU6nEQAAAKUwVp70yR/dG2dcckdLamm2WxavzLsECkBoBAAAAEAFoREAAAAMkpxzDCJCaAQAAECBmGN6q6FzO/X12zPUTmgEAAAABZUGmqZuW7Iq30LoSEIjAAAAACoIjQAAACiMbOi4rJJauX5zrOvuybsMOpzQCAAAAAb5zE9+nXcJdfvizx6O4y/6lUm9qYvQCAAAgFKotgnpxe7e5hbSIivXb867BDqc0AgAAIBSembNpti0pS/vMqBtCY0AAAAojFpmNDr6ghvio5fe1bRaoNMJjQAAACit2x8v9qnokymNqIPQCAAAAArKyeSoh9AIAACAwhCSQOMIjQAAACiFvn6JEtSiqtAopXRySumRlNLilNKsYW6flFK6YuD2+SmlaQPLp6SUbkwprU8pfX3IfQ5PKd03cJ+vpmSkJQAAAM3z+TkP5F1Cy/mkXb+bHl2Rdwm5GTM0SilNiIhvRMTvRcSBEfFHKaUDh6z2ZxGxOsuy10XElyPiwoHl3RFxbkT8/TCb/mZEnBUR+w/8O3k8TwAAAACq8T+/XpZ3CXSgZ9ZsyruE3FTTaXRkRCzOsuzxLMu2RMTlEXHqkHVOjYjvDVz+cUSckFJKWZZtyLLsltgaHm2XUto3IvbMsuz2LMuyiPiviHhvPU8EAAAAsjAEDRqlmtBov4h4etD1roFlw66TZVlvRKyNiCljbLNrjG0CAABAwxipBbWpJjQa7vdqaHRbzTrjWj+ldFZKaUFKacGKFeUdRwgAAEB9yjiVbvmeceOVeR9WExp1RcRvDbo+NSKGDgTdvk5KaWJE7BURL4yxzaljbDMiIrIsuyTLsplZls3cZ599qigXAACA0jI6jQYr80uqmtDorojYP6U0PaW0S0ScERFzhqwzJyL+dODy+yPihoG5ioaVZdmzEbEupfSWgbOmfSgiflpz9QAAAFClMneMwHhMHGuFLMt6U0pnR8R1ETEhIr6TZdkDKaXzImJBlmVzIuLbEXFZSmlxbO0wOmPb/VNKSyNiz4jYJaX03og4KcuyByPiYxFxaUTsGhE/G/gHAAAA0DbKHDaOGRpFRGRZdm1EXDtk2ecGXe6OiNNGuO+0EZYviIgZ1RYKAAAA1KjMiQd1q2Z4GgAAAHSEMs8/Q3OU+TUlNAIAAACggtAIAACAUkiGajEOZX7ZCI0AAAAojJHP4w3USmgEAABAKaRS94xA7YRGAAAAlIPMCGoiNAIAAACggtAIAACAwshKfYJ0aCyhEQAAAMAIynzWPaERAAAAABWERgAAABRGNsrotBI3jMC4CI0AAAAAqCA0AgAAoBTKPDcNjIfQCAAAAIAKQiMAAAAKY5QpjYAaCY0AAAAAqCA0AgAAoBTSoPOnLV6+LsdKWkjrFXUQGgEAAFAYWVZdSvL06k1NrgQ6n9AIAAAAYAQPPVuSrrRhCI0AAAAohZTGXgeGuvS2pXmXkBuhEQAAAIVR5eg0oApCIwAAAEpBoxHURmgEAAAAQAWhEQAAAAAVhEYAAACUQjITNtREaAQAAABABaERAAAAABWERgAAABRGlo18W9kHp2Wj7RwYhtAIAAAAgApCIwAAAEph3ebevEvIlUYjaiU0AgAAgIKSE1EPoREAAACFkVUZk5RxfiMBErUSGgEAAFA6ZQxQTIRNrYRGAAAAAFQQGgEAAFAY42mmWbuxp/GFtCF9RtRKaAQAAECp9fb3510CtCWhEQAAAJSAKY2oldAIAACA0li+rjvvEqBjCI0AAAAojLGaaY48/5cREZGaX0rbycxqRI2ERgAAAJSaKAWGJzQCAACgdMoYFJnTiFoJjQAAACiMrNpkZNBqKSL6+iUqMJTQCAAAgFK5csHTO1zPIuKae5flUwy0MaERAAAApfKpH/+6Ytmmnr4cKoH2JjQCAACgfEpy+rTBo/XMaUSthEYAAAAURrW5yEe+e1dT64AiEBoBAABQemXowslKec446iE0AgAAgBIoQzBGYwmNAAAAKIzxBiOpJHMcQS2ERgAAAFACGo2oldAIAACA0jN0CypNzLsAAAAAyNNltz8ZXas35V1G02WSsXFbvq47XrHH5LzLaDmhEQAAAAVSezDy7798rAl1UCT9/XlXkA/D0wAAAKAE9BmN304lnShdaAQAAAAwilTS0+sJjQAAACgM0/aMzL4ZP51GAAAAAFTYqaSdRqmTZk+fOXNmtmDBgrzLqM9PfxrxoQ/lXQUAAEAh9WURGzb35l1G29htlwmxcUtfRETsMXlidGL08WJ3/j/PYffd298ecfXVeZTTcCmlhVmWzRy63NnTWm3atIiPfjTvKgAAAArpxY1b4id3P5N3GW3j5Bn/J35+/3MREfHHR70mJu3ceQOOrrzlibxLiD9+y2ti0sQh++6AA/IppoV0GgEAAFAYjz6/Lk768k15l9E2LvuzI+NPvn1nREQs+tw74qW77ZJzRbWbNmtu3iXEvZ8/Kfbadee8y2iakTqNOi9iBAAAAGrWQT0jtAmhEQAAAAAVhEYAAAAUhm6akdk11EpoBAAAAEAFoREAAACUQCedCIv2IDQCAACAgnphw5a8SyiGkuZtQiMAAAAKIyvrp/sRfPzyRdsv2zPUSmgEAAAAQAWhEQAAAJSAKY0a47YlK6Onrz/vMlpCaAQAAEBhCEZoprufWh0f/M/5cdEvHsm7lJYQGgEAAEAJmO+pfivXbY6IiCXLN+RcSWsIjQAAAACoIDQCAACgMAxPG4V9M27burTKtguFRgAAAAA1SCnvClpDaAQAAAAlULYuGeonNAIAAIASMHSPWgmNAAAAKAxnCIPGERoBAAClcvNjK+K1n5kbazf15F0KtJRAjVoJjQAAgFL52g2Loz+LeOjZF/MuBegwZRviJzQCAACgMMr2ob4W9s34Dd13JTl5mtAIAAAAgEpCIwAAACgBjUbUSmgEAC2wePm6uPup1XmXAQAAVZuYdwEAUAYnfummiIhYesEpOVcCAJRVZlIjaqTTCAAAAKAq5QrehEYAAABQAhqNxm/orkslOX2a0AgAAIDCEIxA4wiNAAAAAKggNAIAAIAS0IVFrYRGAAAAAFQQGgEAAFAYWcnOblUL+6Z+ZevWEhoBAAAA1CBFOU6fJjQCAACAEihbl0wjZSXdeUIjAAAACqOkn+2hKYRGAAAAUAJFzNP2mDwx7xIKTWgEAAAAQIWqQqOU0skppUdSSotTSrOGuX1SSumKgdvnp5SmDbrtMwPLH0kpvXPQ8qUppftSSotSSgsa8WQAAACA4ZV1Xp5GKtseHLOPK6U0ISK+ERHviIiuiLgrpTQny7IHB632ZxGxOsuy16WUzoiICyPi9JTSgRFxRkS8KSJeFRHXp5Ren2VZ38D9js+ybGUDnw8AAAAlVrYP9eQjlePkaVV1Gh0ZEYuzLHs8y7ItEXF5RJw6ZJ1TI+J7A5d/HBEnpJTSwPLLsyzbnGXZExGxeGB7AAAAQAsVMVArSXaTm2pCo/0i4ulB17sGlg27TpZlvRGxNiKmjHHfLCJ+kVJamFI6q/bSAQAAAJqviIFbNaqZZny44G7o/hppndHue3SWZctSSq+IiP9NKT2cZdlNFQ++NVA6KyLi1a9+dRXlAgAAUFbm7RmZXUOtquk06oqI3xp0fWpELBtpnZTSxIjYKyJeGO2+WZZt+395RFwdIwxby7LskizLZmZZNnOfffapolwAAAAA6lVNaHRXROyfUpqeUtoltk5sPWfIOnMi4k8HLr8/Im7Itsa7cyLijIGzq02PiP0j4s6U0u4ppT0iIlJKu0fESRFxf/1PBwAAABieVqN6la1ba8zhaVmW9aaUzo6I6yJiQkR8J8uyB1JK50XEgizL5kTEtyPispTS4tjaYXTGwH0fSCn9KCIejIjeiPjrLMv6UkqvjIirt86VHRMj4gdZlv28Cc8PAAAAiGIGHnk9pbKcPa2aOY0iy7JrI+LaIcs+N+hyd0ScNsJ9z4+I84csezwiDqm1WAAAABhNAXMRyE01w9MAAAAAKBmhEQAAANBx3n/41JY9VhGH9lVDaAQAAEBhlPXDfZG9Yo9Jwy7/8O9Ma20hJSQ0AgAAoDDe983b8i6hbXVqntY/SuElmY86N0IjAAAAoI21T9yVtVEtrSA0AgAAANrWaEMOU8qn1yiVpMdJaAQAAAC0rXL19rQXoRE0wK2LV8aL3T15lwEAADCiTp0kvL9TCy8AoRHUadX6zXHmt+bHX3//7rxLAQAAKJzRMqOsRYFS2eYy2kZoBHXa3NsfERGLl6/PuRIAAIDiaVUwRCWhETSI97HieXzF+pg2a24sXr4u71IAAKC02umjVtk+9wmNoE45TdZPC/zPr5+NiIifLlqWcyUAAFBeIwU1uQY4JfkcKDSCNrKuuydWb9iSdxkMUbZvE6AdrevuccIBAKhTJ87Lk2VZrN/cm3cZpTUx7wKA3zjy/F/Gpp6+WHrBKXmXQpTmywPoCAfN/kVEhPdHACiZ7p7+EW8z6qP5dBpBgzQitd/U09eASgAAAMohSY6aSmgEdUr6UQAAAFqupdNIdN7IvoYQGgGMoRPHfgMAQBG027F4e1XTfEIjgBHodAUAoEiKdoKXPI/Xy/JRQWgEDdKsN+Bps+bGRy+9qzkbBwAA6FBFC8HakdAI6lRtuv3v1z8WC598YVyPccPDy8d1P4CyW7upJ+b++tm8y4AxLV6+ftzHCQDQLEIjaJEvX/9ovO+bt+ddBuPgGwzoXJ+4YlH89Q/ujqUrN+RdCozqxC/9ynECwDDGOhbPHKw3ldAIYARO3wmd75nVmyIioru3L+dKACB/RctXHK43n9AIGqRg778AAHSYvv4sevv68y4DWqaVIdi2hypbZ5PQCOok3AYAoB0cc+ENceDnr8u7DGipiRPyiTXKMipBaAQwhnJ9lwAAdKpn13bHll6dRhTLWMfib/3tKS2po6yERgAAAEDHSSliQkk6fvIiNIIGKdnQVgAAaDvL1mzKu4S2lhWsh95nsOYTGlEaXas3xvJ13Y3fsGAbAFruFw88Fxf+/OG8ywDazJqNPXmXQItpNGouoRGlccyFN8aR5/8y7zLoQL7BAGg/Z122ML45b0neZXSk6x54Lq5a2JV3GQBVKdvZytrNxLwLAGhXvrUAoIj+4rKFERHxvsOn5lxJ/nwWLR7Hb+XTqh/50PeLsrzUdBpBwzjqAAAA2peglFoJjaBOqTQZMwBAsehKARid0AhgDEU7ywQAQFEJAovHkXi+hEYAI9BFBgBAs02a6GN5PZKksKm8OgEAAACqULZ5oYRG0CBle/OAZrnj8VWxbM2mvMsAADqQTvHyyesnXpYGJ6ER1KksbxalJhBsqTMuuSOOv2he3mUAANAG2uXL+bLOcyo0AhiBQDA/m3v78y6BgijrAR4AlIZj9qYSGgEAAFAIg7/0O2La3vHXx/92fsVAAUzMuwAoCt9lA7Qfc1sAlNdbXjslPnHi6yNFiq/fuDjvckbUyu72dhnq1Uj+1jeXTiOAMRTwbysAQOGliNhppxSTd/axt6ONcjC++6QJVW/mJZMa0zNTtqHvfnugTnmk9Tc8/Hz8/P5nW//AJeM7CwCAztHb1x9//r0F26838jD9NVN2i50cHLad1+7zkqo7tV7/ypc09LHL8nIQGkEH+uilC+Iv/7+78y4DAADaxtJVG+KpFzZuv97fwG93Tzlo3/jkO17fsO1Rv10mbI0zPvN7b6hq/TQkXVp6wSkNr6mIhEbQIFkRBwgDAECH6O3f8Xh829XDX/OyurZ73d8eF3930gEVoQP52jZMbMpLJg17+4QhrWH1/vTK+nFPaAQwBoEgtN7ydd3R3dOXdxkAdJC+itBo6/W3/vaUuP8f3znu7R7wf/aICTulihCiHb36ZbuNensnzsdTS81/cdxrt1++6LSDd7hN5jc+QiOoUye+8VIdf1ggP0ee/8v48HfvzLsMADpIf/+O1wd/79eISZD32nXnqtddesEpVQ9/Gnz2rwvfd9CI6+271+Qxt/XBo15d1WMW1Z41/IyojtAIoAU29+qYgFrd8fgLeZcAQAfpG9Idvm3Om3ocf8A+dW+jFq9+2e4j3jZ1713HvH8jnnOnSMMMOBvtS9/h1h+Psg1CKM8ritJZvHx9bNrSug/qJXvvoAb3Pr0mDvjsz+PGh5fnXQrk7uHnXoz+fu+YUCSbe/viiZUb8i4DKoanvXS3+rtO/vNDM7dfbmZYcNT0+uZd2ubAV+3ZkO20s4P22ysiIj589LTa7jgoM3r7G15Rdx1lmeNKaEQh9fb1x4lf+lV87PsL8y6FAqj3AGHhk6sjIuJXj65oQDXQue55anWc/JWb45KbH8+7FKCB/u9P7o/jL5oXazf25F0Kpdf4VGdigzt3vvZHh406VC6LLH728WNj8s6Vjztap8xLd9s5bvi7342Zr9l71MfvxC6ZoTW/Yo+tE1+/+dUvrVh38D4abX+VI+5pDKERhbStNfXWxSub/2Ad+MZLdRrVwlqSLyFgTF2rN0VExH3PrM25EqCRbluy9Xhr/Zbehmxvw+be+NGCp52Igrq140vo3Ye8avsws5ftvsuw67xx3z3j+ANq64TZKaV47T4vqbu+snB8Xj2hEYXUqA/7AACMrtFHXbPnPBD/8ONfx51PmNeMYnvpwKTNgwOMUT/H+IhTk6EnLBp88rvxBIptmEG2hNCIQmvltwvt+E0G7cU3pgAUWaP+zi1ftzkiIja2cG5KimHoS/ADM39rh+vHvb61k1q30v6vKG6X0XjfWfacvOOcVtU0FkzYKcU3Pvjm+MPD9hvnoxaP0IhC0m5II9V7COzl2Hz9/Vn8/r/fHD+//9m8S2EUw/0uLXxydazf3JghLUA+Gj0ZrOO41vufXy+LabPmxgsbtuRdSl2G/p3Za8hE2I3+Am/2uw9s6PbGMtqvxiWDJuwus8HvH7tM3CmWXnBKTfe/53PviFMO3je+dPqhI65Ttu+BhUYUUks7jFr3ULRYow9avVYa4xcPPBfTZs2NrtUbty/r7u2LB599Mf72ikU5Vkat1m7sifd987Y45wd3510K0IaGDi2heb5769KIiFiyYn2+hbS5oa/JI6dPqW+DDTzW3Gv7ULfRN1rm36pqju2HdieNur06aukkQiMKrcxvirSPspyOs1V+vLArIiLuHzSZsnnMOsPQn9Lm3q1DT+5f9mLriwEarlFf2nXiO/rNj62IF7s79+xxnbjPhzPWa7BVx2Q7Vfkwg1cbWvpwz8UhZW0cHzaG0IhCasY3Uxs298Zjz68b+THL1qdIzbxEGmO0Ayb7uDG29PbH3/3o3nhmzaa8SwFKrFPe01eu3xx/8u0746+/3/ldk52yz9vFSJ85Hjzv5HFvc7TjnJ2qSI22BVZvee3Lxl1Du6nlc9aOQdyO99thwnF5UtWERhRaI4Ocsy5bEO/48k3R1++vadnU+zLyR6k5HNg2zy2LV8RVd3fFZ6++L+9SgBLqtA7d7p6tXZOPr9iQcyXj12G7fETXP/R8U7dfzbHHHxy2X0yaWNvH7B2CjlEeo5qfU0opll5wSlx+1ltrqqEMBnceOY6sntCIQmrGm8DtS1a17LGAkQ3XalyUg12ATtSs92DHWK3X6Z3zl9z0eN4lxL+ddsiYwedwt1fza9SI4Vad/jOOGP8UJPW+VxVh342H0IhCK+evNe1qW4tslmWl/aPTSMPtwXr2andPX3zqyntj1frNdWwFoLzKPKcR5TA0dKg3xBkcHlXz6+NLsqHy+SKxbEfxQiNokNHePAQE5Tb0b9f0z1wbZ35rfi61FEGzDgbmLFoWVy7sigt+9nBzHgCgTv39WVx+51PR09efdyk78EGWTlHvS7UVh/T1zmlURLXs9pYOQSvJj0NoBDUSAJVPoyZWH/zSuW2E4Y71uv+ZtaXplBn2V9GvJ1BgV9/zTMz6yX3xzXlL8i6lJYrylv6Tu7tiWZufWGDbB+1O2uc9ff3xjRsXR3dPX2zu7avqGL0Vz6+WXKfWzKHas7Jts/du1Z8+vpM0Iqspaf42LkIjCq0V+U4zztRGe2jYRJwt/Kv0rq/dEu/5+q0te7w8DLc7G/m77jcaaFdrN209pfsLG7bkXMnwGnVMVKQPc909ffHJH90bf/Sfd+Rdyug6cJ9ffudT8a/XPRIX/OzhOOCzP4//KEGYWuux6SdPOqBJlbSv0c6Q9nsz9t1+uZ5jx7I1EQiNKKRm/h6PZ9Mle18prJ/c3RX3Pr1m3Pdv1cugLKdJH+7DSV0fWDrwgJmxCfYZanNvX3xz3pK2G+LVyRoxOe9wivDBrH/gOSx/sTO6gDtpl28aOGvdk6u2nrXuqru7mv6Yjdo9235jtoUa1YZBtXYaDaeDfsQN9/7Dp+ZdQkcSGkGjlPkduCQ++aN749Rv1N7F0+hD6S/94pGYNmtubOkt5wee4T6cNDIY6KQDZuq3pbc/+vvL80N/bm13/OKB5/IuI1ffuvmJuPDnD8dltz+ZdymFU+3750PPvhh3LX1hlDWk+K3WDnv8qoVd8dNFz8SNjyyPNRvbs5uumU45aGsXzKtfttuI6zSsC77DjPfYrFnHdGX7OQiNaHtPrNxQc3dHM79ZbvSbz3H/cmO862s3N3ajNFSrQ4Rn1mwa9Rvw7966NCJ+8w1bmVz484dj7n3PRsTwP5d6flbt8uf//mfWxuLl6+vaRm9ff/TVEIRs6e0v7FxYY3VAvP6zP4uzf3j3iLf/8qH/v73zDo+jOP/4d1RtSZZsy02ucsfGNtg4mN4JYEioIZBCTwih5QcpohMgwRAggQAxxFRDMA7NDrKxjXvvvciyVdxt2ZZVrXK6+f2xu3d7t+V2b/du9/bez/PcI93e7MzsvNP2nXfeOYyHPlsfMZ35JUcwb8dh0/kzQmOLD9f8czG27K+xFE9ZVT3OenEufj15rU05S0wamn0A1PtQX5tft/2daGxJypfZSMjfny55dQHeX1KuG/6q1xfjJxOXY191o2645FHn2g/nHF+u3YfGFp+5+xws9Uf/uxEPT9mAOz9YjV99vAaA4Pxda06k6N8TsMLI5y23nd0P25+7Ej07thd+U3kgBmBkr7w45c69OCVqSV5esII0AymNCMusrTyOqav3xiz+i19ZEGLdcay+GYVFxZi6JnZpRoNe1yE3l/3leyuxtjK4urbneCO27K/F9oO1uvG/NrsE83ccUYRrbQtdJZ+2YT/WiKt3C0qO4GRLGwqLivHa7BITTxM7Pl+9B69/X2pLXNsP1mLD3hNoaPbh8tcWYtO+6LeOSUxcuBs3vC3UN7uVCEbGl5qTrTh3wjw8PW2LdiAxY6WH61BYVKz5Ijl944FAXTDLI1M34J9z7ZGTncidv8qL016fRs5OBK755xJc9tpCS3EMfnKmqTh+++lanPHC94rr9c0+FBYV48u1sTf5d5IZm7Utb+7+aA2mbzwQMY47P1iNuz5cY2e2AqytrMaW/bWWT/a75FVr9coKayur4XPZdjC1Sf+EmTtw2WsLsfd4qDJj3Z5qvLtoN05/bg5Of26O4j5pbrJoZ5WpPKwqP25JCfXdloM42eKeBQQOoKyqAc99u81Q+Hs1FJhJtogfE1aVH8ej/92IP083JgutMi85VIchT86M+9b3siphy1nRV5sw+ImZgevnTpiHc16cGxJWsvpwYvQ2MmcY2DXbUFyMMbTPSNUNk8IYpt57NtY+eZmhOI1QeawBt767AvXN5hSMROy25roNUhoRlrnxX8vxxy83gXOOv8/ZaWiF/JfvrcTNE5dHlV7FMWEi99mqPZphYuvTKDRyI2n94YtNgf8Xlx7F/32+URHmqtf1rY3emLcLd364WhFu8BMz8dhXmwPfH56yATdNXI7Sw3W444PVeOKbzYH73cCfvtyMv3+/05a4rnp9Ma57aynW7alG6ZF6vPSd9aPSJ8zcgXV7rCuf5JiZ/Eor4PN3RH7xmL1NsGqYIVrehPPQZ+txk0Y7O1ijP/n7at1+vDrHHjnFEytN30umxpwLVppG+X77EdXr+6uFevLOosjORQuLivHs9K2G0ySSh837anDjv5bhldnu6FP0mrq0ZepYmKPpG95ehr/OUI4xkxaXobCoGGsrqwEA70WwsJHja/Pj5neW47b3Vxm+R86W/TX4zSfr8JTeIkOciLb3bI6wzTrJFvM1mbJqDwqLitHsCyoII21VbxAtjI7UNZlLLKzM/7OyEi0+f9y3tUrZmLomdNFi/4mTOFAjPJNbh+3w+cS0B85DL9F6SBlWJx6VltWhXRraZ6QiPyfTWGZUGlH4pZdnlWB52THM26E+F/Aqbq0/boSURoRt1JxsxetzSw2dDrG49ChWRWkBYQfSiuBXJhzmRZq3ONnvfK5idVXbJEwWpJUaL5M4Wv7Is19pANNbuZKeNlrT2PklR3D2i/MwZ1tsttI4ga3vFfSSEiCwemuwTD5cVhG7zBC2Ek/T+qp64QWv5JC+Ra0rCNR5Y+Xz5nxhQSaaFXopha0HoiuX2ibhJLVwqygnMVuvtMInyqgeL6RFnBONrYFr0lb1Jp89lmZac6lEWlBxYsuQkTloTmYauueGKnnMFmt+dgb+dOUpeOpHw83daIBEkLAZK3B5nQ0vZ/l3Ukobh5RGhG1IDS8RTiORVuA/XaltraSFVgfjtn4nqHxwD1a2Mfr9POKk3K2dvxmllhS2urEV0zbsVw8TNgKafexNe4XtbHZs53MbViaMAWWcPVkhVKCydQ9u7S/jgdTP2lEGQSW+lXujy0jgOaK62x1EznsiP519WKlnZtFKIt59hpl2YSasWxUkavmSK0oYY7jvooHIbZeuev8d5xRazkMi+ekxmtcEeiRXQ0ojwpPEon9w6yCjhRvz+8cvN0UOpMFrc3ZixDOzUCNbZZMIKMhsath2IQAAIABJREFUFrzdi2tm8tfi8+PhKRt0V5DNWoF4DblzYjsmOgm0mBp3ErmKOe2jinAfeosqZpXHVqwweNhfszAPa7qpPw4lHuURKY14VzMj6YW3P8mFRUxxaNIVST5n9OtkIW73N7jGZnWLOrWsu/9pEg9SGhGERVw/V/OIRkFyRFut4jDU7YODmbE4PKyav4egkizK1Wm3F5gF7KjtibTSZjfhz261roXj4aqXcCRvLQ+iVq2jXYSIpjytNis3taeoHRFTRTRFPJTg4fXSLXMGu8Yhx07d0rquk6F4uV9wiYh1+ZkB9yfR0sWof6gkhpRGhCeJ5UtforxPOnmSRCwwst3O7RYFU1bvjbhFTzlwqx+3GhrCrA8JU8ETAjseyS0TYydx68uCFeyadCezMtFr2FmtrW4xE+61lgc3jH3RlmmknHuh2dmzDTL2lsURLY3iLIzw5FSVvNJfE4OVa4c1lYzZ0bbVY9C46uL2Jjk/jwUzHjrP9D0uLqqYQEojgrAJt71QxHP/ezzQnZjHaHuahJ5sW3x+1JxUbpnTwuwWPd0VKDc6rnIYO+pAMhen5kpoXHPhTvwuKIR91Y14bXaJLeON28YsJ1B7IWOyX41gRbFq9YXQjVuU7cpL4hxwER/iqcAPr5dOySK8j1LdTmqzNawTuGFxxsghLG7DqKLQyBN1y21nIR9R35pQkNKI8CSx7PISpUN1uhP764ztKCwqti0+vcEhVhMaI7He/v4qnPbn2Zbj0QqsPkmy9rxO141YYOdKbjKj2J4Gdyom2/zcgVVv5wuh4lgj3pi3C7ur6i3H5fzTOIiOsiVaRYwj29Oi6LKO1jfj1ndjsM0jyu4zUrvyQj1NlGfQPj0tzhnRQK2uuCRrUWG730wL9yZiObphTE4mSGlEEBZxe6fllJLr3UVlMYlXf3ta/FledszW+KJRXLitBm7ZX4P1e6qdzoZhdh2pw/fbDge+Lyk96mBunCXcmsaplwW9fvVEYwsGPj4DkxaXxzFH7mpnbrB6SmTsrdbOK1bNJP3x8krbx61QTG6X1rjuFkWFUfSmgrYc1CDFZTmmyGieEhznOh6enFv7vURZTDaCy19poiLBuhLXQkojwpPEstNzU4eqNxGJx/73eKK33c7tJ8hY2r6gs4c/GMZdD37NP5fg+reXxTdRC0Vw2WuLcM/HawJyOtagdLaeLGhNft1Uww7VCn4Nvli7L67p+l3UzmzZhumex3EMOxYhnFRu2OFPyS5iVQwueDRXELSAi12BaNXl4BTLWa2RXelbjSXRqqRalVH6L/TWOwNhP6Q0IgibcKKf1fd3E798xIXA88TfPDmesg2Xm6rPDQ/s4SfciWIiGbjurANUN+DGPFnBS6vjZmE6qxDR+gOMpjyd2J7mNrTKINGeTS+/dra0ePRD4Um4RRZ620mddIRt19Z2J4vZJSImXAwpjQjCJIk2zXb6RSeeR3Xb/RIkTUI+Xl5pLR4Tw7GR00IQZkXmtIzdQDK/ANtJrOsSSckeqL5bQ69PNquUd8OhE26qDXaXA9V19+D09rRkn+tEmknaofjxYhHH7Jm8WFg6kNKI8CZxbMhunyg63afZvQfdTseliYrSGskcyVJOZonGwfj9n67DuRPmxSA3zqA4NUdqW05kxmW4qd3Q9jR7UD1owOSrl5Onp4UvIDhJtAc0aJWBlw4msOWgBj1LJtvnWe4cB9xiee3WEwItZctjFuyxfAoti2yvQ0ojgjCJmzpUXZ9GLhkA7PIDojdpcYvptB2ET4p0nWvGOC9EZIo3H8T+EyedzoZtaG9Psyd+o01V19eMQxXfaz6N3M7FryzAE19vjkncRsYM08r4KPLhxe1pdi9ieKKu2/gMquVhV/+sUaGcqmbh81c9H4+JWE1OtrY5nYUAAT+oDueDcC+kNCIShsKiYkxds9dQWCfMmT0xsYkBei9arW1+W7cAuFYEZmZcUTh+NFv33PiiYRVbVnKtR+E65KfCGSHeihErqcW7Hrupf0mGLTvlRxvw6co9tsZ5/6fr8NqcnYHvqtWd6fymGjz21j6+Nj8mLtyNprCXzNqTrbFL1CRe7D/dRGAhMA5tXysFp7en6Y1P8cybXWPPriP19kQUBW71W2UGoyJPwEdzJaQ0ImwjHv311NXGlEaxxE1Tdb28SBNZp1fHtZJvbfNj8BMz8Zfi7Ybi0RvQYuWs1w2DqO7KmuTTyOwRx26qxDHkor/NxxnPz3E6G45yz8drTIVXVI04vqiE5MNAJY37C4yLGg5tT4uO4s0H8cbcUt3ToMx2+1Ze5o3eMXXNPkyYuQNvz98Vcv3Xk9cCABqafabTjhWmHYhrhXfB+GsXdvSfeluZ7OqfNVNwaBwIR93Fo3kLGatzu2j7zs5ZGXFLK2oScFyIJM4EfCRXQkojwjZumhj7I7aNKkCSZTJs5PQ0p8tCK31fm/DDJyvNOZnW29NuJ/N3HLEtLguGRurxuWQC5ybUSqLiWCOONbQYjsMNSkKniXZ7WrQKFaf7JzPY7Z+NcA5j29OCAl+0s0o7LvFvNPXDaLtpbBGUQvXNoZZGLT4/AGERxmliNS5RswvFyPHpduOUfyljB4NIvxkvhFiU17cPnoe/3TRKN8yrN5+m+3u0fsHsQE+RThAAKY0IGymraoh5Gm7oyowMNi9/twOFRcWxz4wBnC4zLUWfNDYanWgb2QJg57Pe+eFqG2MzTjSTGdqeRtiFwoeEQ/nQw7H668bCsIAj27jjnqI+6gcrSD8Gr23YeyK6yCLdYvqO2MZjB/H2f5YI2OkI20lZx397WrhPI+uWgbFiRK88/GRsH90wHTUsjYwsABtBS3FmRKGWiPPCtJTo1BipNj1ssinYSGlEJBRuXpWWdx5vL9gd9zTDCSplXGhODJksjSqNdC2n3HOCjBpWVo/Ut6dZG/DcWk5WsGPrkJdO64kWrWK0y1lteDCtPsyNVdRNE0TanmYNvT7Z/OlpzjuQbbNgBje/xD6rWsD8nCNS3+2mbaFOorcN3/YS4oL1ml+sV25RKOgpeeM51w2XQV5WuqX43OKryYn0ouHqkQX49sHzor4/JYVh0m1jDYe/+7z++Ov1IzV/d0v7iDWkNCISCqN9WUz7PBORx3qyo7s6ARcsS0F7MJRewNz0IhaOE+OAkfLQUqCZrW9JMs4RJlDUoCiVQV7ETdvT3Nxv6uG2PkevFM2WsD+KCmLXFKGmsRXTNuyP6t47P4hsVdva5kdhUTHeCvOppIZpn0Ya153cqmM3dohZTzlp11xTvsVw8BMz8bh4eqFbJKHbXk0Ugd1Vq1fH9pbuN+x0P0K+zbQZ5VZ055XfRjl/cBeM6JVne7y/u2yw6vWnrhmOn43ri1d/ImwvTNTx1yqkNCISC5uVMGsrq7G7ytrpBXpZcsNLhtNZ4BquFqRyM1tGep21089qBwpFkAFHrdKE0a7JeiJiz6Q8cpj6Zh9qGt1zYpHd+KOsS0ZR1l31cG5c7XSTxYMtlkbWo4gLpYfrYha3nuVCXPpTm7YW1zX78PCUDSg/Ghs3AdLR4BN1rKiT3VLTLn87VtKxSrgEp4QdPhPNc6wsO4abJy6Pyu9WeHJqi5DxOL2wk0VLokjE2krKSOyJqKP945VDMaJXLs4Z1EU33Lj+nQ3F9/Cl6kojiUQsIzshpZELqG5oCTg5JPQxqmAwM7AVbzpoKg9mNMxOvmS4ZXuatqWR+Ndg/gKrbHYtNcURK+OMkUdy51N7k7EvzMFpz812OhsxQ6m0lK57cwuJKeepMcyHWezIi96z+/084GTZaS7/+yLb49Q9jdNkhx3PQycipXGyJdRR9q4j9XhnYXy2y0c759AKnuTvZwqC5RH77WkKKxQLdfz3X2zEqorjOHiiyXw+IuQrNKyZubm5fMx4+PyQ7z8QlRA/G9cXE38xJuS3iglXo2LC1abib7PQeci3WdkxDhuNovRwnePj/pDuHfDtg+cjJzNNM8yd5xaiXXoqAGBwtxzd+BhjuPeCAcjKSI2Y9vSNB1AWIyW9W9EuZSKmVNU1o1NWOtJSUzD6+Tno1bE9lhZd4nS2XI+bTQLV+s5YWxrpr2xFDhMPtJIPWDQYjEdvAtnc2qbza2KhmCTphbXotNhLk3JbHI0aCNPU6o4XabthTChDM31sfbMP5VUNGNk7L+qeWes+N/b1Tivg5cR6sv7ct9vw4bIKlP11PFJSvNRTRCa4TcPogobwN5r6YaWeHzhxUnEtPA83TVyGE42tuOPcQmSmRX4RsgM7rYcB5+cwdmDLI+gcHmKb83ENjakVKzLp3qj6T/EWvfHJ7KEq8nv0mPvohfhs5R5MWlKOgrzQ7Wen9swzrRiSWPX4pUgN61P9fmP56tahneLaZcO740en9cT/Nh6IKj8SZk4/3Lj3BK59aykeH38Kfn3BQEvp2s2ff3wqPlharvrbN/efi9omwVK8VydBpmP6dQoJ89j4YXhs/LCI6Tz02XqLOU08yNLIAU62tOEHf/keT03bEri2X2XwJ5RE62zViTwA7njxcSoPkSbSZpVaeoPpzyatFOIymjmj2GSLqhXN5BWVKCwqDlnRN3bKReje82gnjM7XTneRzKbHQSerode5jnL33slr8KM3l6BJQ2k7eUUlKly+Emeq7biowdhiaaTz2+QVlQAAnxv2WMcAPcWQmyyH9Ji97bDi2jX/XIKfT1oR+N7QLFix++Oo67bbv44VNuw9gW/WR+frya1IxdvU2oY6Ub5G53nHG1rw8JT1qG/W392g1eyjkWyKDUpVrfFJ/puZzHXrkKn7++XDu2Ng1xw8ec3wqJVDmmnntkN+Tmj6RsrmilO74707jDtvjoSynRpvcNe+tRQAsH6PgVMlY4Bead1+TiEW/OFi1d+yM9MCCsBhBbmY9+iFuO9Cdym93AwpjRxAmmB/tmpvVI4Tkxk3rjjp+tiJtaWRrn8f4bd4ThblSMOP5mAYraLDgHWVbcRYgK/MKgEQnNirZyFyHgJOxd3YQEwS7TO4QUGbKDQ0+1BYVIwpq/YoftPenqaMZ12lMGH0c6743dfmx1PfbMGN/1qmm5do5H28vkVxze/nUZ0glaA6I1vQK3rpRc/KqVzRsGhnFWZuNrdlPBoCCglbLBQtWFKYTcvAe93SXceC4cW8+SxOBMw8mmlLoyiLbdLiMmw7UKsb5rq3luJ3n2+ILgGTxHpuEj6neuLrLdqBNXhjbimmbTiAqWG+irTSCFy3oEiVLBXt6Ers2p521cgCAMCEG5QnYr184yj828TJWnbQXtw+9cuz+mmGuX50b1VLIzP06tgePXKFOPYcb1Tta8219cQeFQd0zbHFkjZZ/LmR0shhBjw+w+ksRE19s0/VPDqWuKF7MvWS4YLtaXawtrI68PIwf8cRrNtTHfEeaYJQckjdianeAL9uT7UiDWnSsvNwneaExywNzT7dFbenpm0N/C9X8O46ou2YtfRwHRbtrAp8/92U9Xhbx3koAGzcF1ytCZfbvmrtNqb1gq/G7K2HMH9H6NHKZoa5o/XNlp3Gux9zA/+Gvc6sslnlUK3gW+LdRWWBa0HrtSgULyrbBqTmUnPSmNPwqrpmRZwSjS2+kFObJMvCYFiOGycuw/jXF2Pqmr0BRZSvzR+ilHrqmy2GnJh/uLQc324KmvpH88J07VtL8chU7ZdVzjmW7joavZI0RmPLd1sOYvvBWqQwe5QNZrnt/VW479N1cUtPd/uvwTisvFDHaopwqKZJsGIVnQ+PfHY2Bj0+A4VFxXhjbqki/KTFZfDpOCqW6mldsw/H6ptVwwT9Dpp7qkihw/uWhTurMH3jAbxQvB3j31hsKI2Pl1cYzk+Lz4+Rz84K2e4zeUUlXpyxHQCwad8JjHhmFo5qlIMadixqhPt13CSbN8ij/2LtPstpyWVYWFSMleXHxWTMP0fQSii6sQXQH5+iaX8XD+2Gjc/8ELec2Tdw7avfnoOKCVfj5h/0MZ1Pq5QdbUDZX8fjkcuHKH4bJPrh6dohw3I6lw/vjtduFk4A+8MXm0L62uD2NOOEKwILi4pR9OUmi7kk3AopjYioufbNJThnwry4pikMOsoubfLyipAVbSeU32pJag2w8bSKsGp9srbyOG7817LAS9udH67GDW/rWw/IeeA/6vt+tVadzntpHm54e5kiDUmT/+h/N+KPGoOS2XI99ZlZGPHMLENh1+8NKrEue03bMevlf1+E295fFfj+zYYD2HVEXdkivVDfoXPk8YNh+6Y37Tuh2M5qRMS/nrwWd34Ymo6Z0rrg5fm49NWFJu6IM3Fu840tPlwnmmh7geAKs/g9bEtBpFMLjZxyo3qvgWCvzy3F30SrPDlSHt9ZVIb1e06g5HAd/vjFJtz3yTrUNrVi0BMz8S+ZE+DVFdU47bnZIe1HrX989n/bQvqtiFaTKmzcewJfrdPeFjN94wH8fNJKfK6iAL/yH4sw5vk5EVKwY9leeek3n6zDVa8vDiqN2tywVGM/eurhWCk/VO+xyWl0OI/+V6mw1Ntq+ELx9kAbG/LkTNw7eY1mupICQTOPxrIYES0Z3f7+KtP+RJ6etlVzHA7neEML6pp8eKF4W+DaU99swTuikv3fi8tR3+zD0l1HQ+6L17xOLR3piq/Nj9//d2PUcWv5B1oVQeZ6SH2JFUuj8PFJDbPR57UXTkR75Sen4ZQeHTCmb6cId8SWlBSm6lPqkcuH4LNfnYUz+mmfANa/SzYAoKvGtrts0VF0Zrr2a380tjJq/deU1Xtx3ydro4jNTLpGwsSuPSa4gVXUkNLIAbTqWqJtLdldFX9fFVpF9NS0rVhbGdn6xZ48GJdTzB1h6/3G7cnD4VphNS2SGbgWWquXWuWoZVljxCw/lk2oxRc58vCTa8wwceFuTd8wcn78ZlBREdiWJn2P4fM3Wng2MzjZDZrxodFqoD64FX0LRQ1Ft849asqUSKcmmkm7rknf/8aMMBP777YewjFxC5uaUmb6hqAFgVPb0w6IJwmVH1OOozsO1eF4g3ILXjyRHLV61aeRhB3zrmiUimo0++zrY6MZi9bvPQHOhVPzZm0N9Zckf7ZIWxbNFkOk8HaNCXaVb1R1xsbtaXrJWzmFKyQeDRlHtT3NihWrIn0VSyNEp+SVuOmM3vjudxdEdW88SEtNwdkD83XDPHTJIHx6zzicM1D96PlrRhXg3gsH4IGLB0VOUFaODc0+PPe/bZr9iVY9mbnlUOR0IChojcx7FVk0UZfs3DomzREvfc3FC6gxhJRGDqDVsbXomAYTAkJHEbkDsGPFZ9LiMmzeV6O4/ttP16GwqDiYVhQvYHZ1YnqT1KBCwVpZWH15aNWafESdI2cw4ttj2NPfRR3/hJk78O6iMnOO1nXCRnJ0Cbjj9LQZmw9iusVTP4D41yev+VDSMvE3Uh/VfPNF4wtHq49ZFraiL3HgxElDE06rsorW8kSPVHH21WbQkuedhWUh3+3Iil65SPUh3j6N4oXelhaz7o7Ctw2ZQX7LSzOD1nSPfbVZdcHFqGI7mvG6zc/x0ndKiz4gdPFJa94RvfJMIz6bTyaItNPS7+d4ceZ2HKiJzu1CrBc89OqsdM16e9X3zxVN7AHrpShecaQ+V3cLWoTT0568OvJJWIlOWmoKzh2krjACgKyMNDx21TB0aJeu+E1RxrLf3l1UhveXluOvM7ZjdcVxlB9twN7jjYHfrVa3Mc/PwU/fXRE5oMvw6rgYCUNKI8bYlYyxEsbYLsZYkcrvmYyxz8XfVzLGCmW/PSZeL2GMXWE0Ti+jtRLQ7COlUSSEootPY32heDt+9OYSxXUt0+wWFflpn0BhzzO06tQZqZpZncikMv1JRCS0LY3MxRM+fVR7gdOKs6ax1bI/nkgreHa8UDY0+6L2KQOE1iuj2+4kNu+rwYqyY5ED2sxvP10XstUg/Omr6ppRWFQc4icqVph5RUnkOYPeuxjnCJkUBuuWNn6usj1No2vSK2O1PhQAKo41ql6vbfLhlKe+wyYV5b6R9ABj/ZCRFX7t+NVvklbfw/sVNWWv38+xJExxZrdT2ZJDdSH+p6T8tSb4Yta0Dfsx5ImZCuWi3sKNnU6yIyGXQaXM6uyzVXssbQnSaxNaNPva8PlqpXN8ILQe221pFAm74ovkn2vjvhN4Z2EZ/i+C4+xolFl2Fon69jThmpZs9BaROOdobPGFXdNOv83P8ef/bQ0ZJ/RgFueQgNyaSO03Aa3YLx3WPep0PUlY9ZXqjFqfKP02eUUlfjJxOS5+ZQHOf3l+4PeFO6tCfH+Z4aConN0YhW9It23M+XKddT9iiUBEpRFjLBXAWwCuAjAcwK2MseFhwe4GUM05HwTg7wBeEu8dDuAWAKcCuBLA24yxVINxehatyh6NiZ6bqW1qxXtLym09Ic5wTBaTVFVIRBWRtXxEwoh1mtXiT00VX24MRPT415sxeXmFofRNW9aFTdTU4tXK4fVvL8Wlry4MdRxpkkj12JZBLOqFVW45Dz96cwluMbDiUy4eob628jjWG3CIbpWtB4SXn38vLtMNF+44Wc7KsmO2b/81u9I0b4fyeOxwlu8+hjUVoS+KZVX1GPvCHOyrNjZBj5ZW0eLly3X7cP7L8xXKcdXVbemERhPb0xRxyILJlUZ2issuy85PxGPozXDPR2tUr1eICgJ5v/LW/F34q+hsV06rysuuVn2uaWxVOBUHgH8vKguxkA3nin8sws0Tlwe+O3F6mt1ttMXnx3P/24aWNr/mdj+9FI0q8AMWNmJZLdRRcPv93JJD4FhysqUNaanqrwXy5LXqRNAaxFxmj9a3oLZJUFjWNbXiUI2wddNuS9hIfdKT3winkTW3Cu3N18ZVx/2TLeoKmA+WlkfMg5UFw+ApfdphtGSzukJ7rP5gaQWGPz0Lh2qaFL7swnljbimW7T6KD5ZW4NGpxnwnpajEOXl5RUBpoAcP/OWBv+HjezCwep4lfz+EOtLCRbQO/cP9bko0tvgU8xk5F/1tQcj3lWXHUO3wtuxo8fk5pm3Q9mHoFdIMhDkTwC7OeRkAMMamALgWwDZZmGsBPCv+/wWAN5mgWr4WwBTOeTOAcsbYLjE+GIjTs2h16tJABQgTCz/nmgN4rKhuaMHEhbvxyA+HIDNNOAKSc47N+2swsleeoRWWE42t4Jxjwswd+M/KPejfJQuXnKKu6W/z88D2J4mgqaQyLWHQ0c4D5xzNPn+IiXVTaxvaicdZqvH56r146NLBaGzxISsjLZAvOV+v36foSNvEyZ/8cm1Ta+DozGB+1fIpre6oKwr9fo66Zl/AUZ8WeicTSX5A5BM4zoV4G5vbkNs+DempKUhLYWhoaUNOZhraxHrX4vMjOzMNnPOApdGRuuaQAcDv52AMOO+l+fjl2f3wmwsH4j8rhVXKX5zVLyQvrW1+pIfV5Q9lE6yqumZ0aJeGY2EDRpufo6m1Da1tfsVqhJqzx9Y2P47UNaF9eio6tEuH38/h83OUiYqOH7+5FOUvjsfuqoaQVce9xxuRl5Wu6bQbAOaXhJ489s+5pejZsX3ge7glwBHxhCozLNp5FP3zlROc2ibhRbAhbLXwiPhyuLuqQXRYvlxxL4AQue2rbkST6NvhSF0zDtU0haxCNjT7Ql6wNu+rCalnr8wuwV+uGxFIa/OzP4SfCxZlKYyFxLXzcB22H6xF+/RU9O6UhSZfG/p0ysK6PdXol5+FXrLyW7+nGoX52SGWFzUnW5Eh1pum1jacaFROKJaUHsXe6sYQWdz94RpM/OUZge8/fXcFXrxhJK4ZVYAWnx8cQE5mmqiICfYncmvPPccasbe6ESN65iGnXRpKj9QF+kRAOGVKzsGakzhY04RDNU1o9rXh3EFdsOtwPbIz09C/azbu+jCoPFhRdgx9O2fhnAnz8IcrhmJ0n44Y068Tbv13qNLuSG0TPl5eiaP1LXh/SQXOH9wFA7pmo2P7DCzYeQRnDRD8HOS1T0ebn2P7wVp8unKPQiH7zfr9GFvYCZwLDpgl58ZlRxsC5S4xTzxhb/JyQUEiOY0+Wt+MVeXHkZ+TEei/msQx659zSzGoe4dAHB8vr0DHLOGkF5+f43BtE1p8fmSkpWDnYeHkwRmbD6J400FkpAX7hUembsD8kio8cvkQjO7bEVb4k+gsX81K6eVZO3BKQQfUnmwN+BYChLokfyHZXVWPp6dtCWz1eWdRGd5ZVIbnrxuBdZXV+Hr9fozolYst+0P9vX20rCLw/9wdR1BYVIwRvXIxrn8+UhjQu1MWPlkh9JUfLa9EN/EI5HBn3y9/twPH6lvQPVfp3HT2tsNIS2X4YGkFxo8swM7DdSjMzw4cL/5/lw3BdaN74pMVlWhq9WOyisJr8a6jKMzPCoxtJYeDp0JWi6fMPfftNgzqlhMol1G9OuK7rYeQ2y4Ne443YlTvjvh4eQX8HLh4aFfML6nCmf07Iz2VoeRQPf54xVB0zc3EK7N2AgDml1Rh7Atz8Poto7GotAoLS6qw41Ad7jq3P04pCNah8JPnXv++FKN656F9RiqmbTiA1BQEyhAQtpMv3FmF0X06ovJ4I24c0zvkQIJzJszDyF55ge9/EZVz83YcwZi+ndC/SzZqm1qxv/okFpQISp+7PlyDz351Fppa21QVhpMWl6EwPzswvqyXjVEvfbcDpYfrcf/FA1FyqA7vLSlHqcwR830XDcS/FuzG+YODW0rmhp1uOWlJOXYcqsPhuqbA9sT3lpRjjMW2oUVTqx/psvnYsl1HAycVju0XdBL8+eq9WLrrKHZXNeCWM/tgYUkVZm8LKsXv+TjY18kVlWf06xTwPTlYPBFKYtSzs/GHK4aqOrx/d1EZapta8dW6/cjKUM7lPlhajsWlRzFvxxHcOKY3dlfV4+fj+uJk2ELsrz9ei/suGog9xxuxpPRoQG4AMHXNXmwV/TZKp0sea2jBgMdn4OwBQX9UYxLeAAARH0lEQVQy8ud54ustyExLwYETTchMT8FHsj5z2a6j+GbDfvTLz8bxhhZ0zs4IlPGfvtiEAzUnMbpPR6SkMIzomYftB2vx6hyhjYzqnYcHLxmMYQUdsH7PCZQerkN6akqgfUqn2crr003/Wo7CLlk4WBM673juf8HXqse/3oxZoq+ZBTur8OlKoW+Q+vhr31oS8GH5iI5C6JfvCe1qVcVx3Pb+KnTJzgCH0F/mtkvHVSN7gIHh8a83h9x3z0drMKhbDppa27Buzwk8NW0rJtwwEnurG7HjYB1+e/EghWU658DZL84NLGrM2XYYLxQHFeuFRcXo01kY+zeqWNdt+fMVimtEKEOfDHWr8Mz0rXhm+lZFuH/89HTktk/D99uP4Men9URrmx+3v78Kfi7IQd5OAGD40+rW7umpDBmpKSHzrbEvzMFR0Q/hDwo7oW/n7ID1To/cduiR1y7ktFqXGRoBAB6esgHXnt7L6WzEFBZpRYAxdhOAKznn94jffwlgHOf8AVmYLWKYfeL33QDGQVAkreCcfyJefw/ATPE23TjVGDt2LF+zRn3VLlHYeqAGV7+h3PKUKKSw6CxXRvftiPV7Ilt59O+SHbBkGF6Qi73VjbpOUHt1bB9yEk5OZlpEXy7DC3Kx7aC6U+duHTLBoTz+WY9IZdI+PVUxeTFKv/wsVGpszSAIgiAIgiAIIsjwglwUP3Se7X6x7EauhKyYcHVc0lxVfhw3v6O+wKjFlj9fgZxMpZ3Jj99cEtVWWKs8dMkgPPLDobphJi0uwwvF23HXuf3x9I/s2cz0yYrKgEWiGvGSYaxhjK3lnI8Nv27EjEWtxYW/ImuFMXtdmThjv2aMrWGMramqir1Pi1jTJLMmOn9wFzx/3YgQyxQ30yO3XUA50qFdZCO13p2CK/+1J1s1n1MeLlO26pydmYpBYatRANBOdmQkY0CuLC8DukY2Q01PZSErjnIy0lIU1j3ylXA1CiOYvuYYKCsteogr0LFEsvTqoDIgJCtPXzMcT10zPMQSxilO6dEBZw0IPWq1IK8d+nbOwrj+ndG3cxYAoG/nLKQwBCxz5Fw8tGvI945ZSgs2tQnBqN7KdnLlqT0089q7U3sU5gv5MVp3pVVCrfhO652HLjmZOLN/55D+AQDyxdVbI7RPT0VOZhrSUhhyMtNwzsB8nBfmOFLqo9qlp+CUHkGrh/ATR7rkqB9rK0dexteMKjCcTy3SUpTDZl77dPTMa4e7zu1vKe47zikM/C9ZtXTJUS/bbJWVfgl53esn1gOJy4Z1N1RuEsMKcgP5mf7AufjL9SNww+heOGdgPs4s7BxSv64ZVYAuOZlQKSJcMKRrSJ67iUcSn9ozNyTc3ef1R3oqwzWjCgLWHz8b1xeA8AIi5+KhXQNjzcCu2YHwXTtkBsas/l2ykZ2RGiK3fvlZYCxUlh3apSmOSc5IS1G0xywxrpvH9g7k/cFLhHp5eh/B8qRDZhquO71n4B65dYjaWCrJQxoP5eXXM69dYOxLTWEY0SsXp/XpiB8O74701MgvYvK0B3TJRkGeIK+OWelIT2W4aGhXXDUi2Jec0qMDfi6WN4AQC5xw+nRuj0HdctAvPyvwDNed3jOQBiDMDa4f3Svw7PL2eM7AfJwmlpnUf144JLSPPKNfJ6QwoW0M7paDdukpyM5IDcwPuuRkIDWFhViBqVnBnD+4S0hZAMBZAzor+p6h3TuEtA+1/hgIts8eue0C6eVkpqF7bibOENO54tTu6JydgUcvH4KlRZdg1ROX4vlrT8Vlw7oHnlN6Pj3C27DEGbLnYSw4hzt/cBcU5LXDjWN64+FLB4f0IeGWRUCw71frx+XzvPA5mLxvHtU7D2f2D46PwwtyQ+Zw4X3vNaMK0FOsJ/K5Z177dM05qpSevH5JSM+Yk5kW2AZ1/uAuGCpaXoaXIWPAzWN7IzMtBZcN64ZhBbk4s7AzTuvTEaf1zguM9fnZGXj+uhEhfc/IXnk4f3AXnDsoH1eN6BEyHqrNadNSWGAOM6wgFxmpKejaIRNj+gppSQwU+zK51f/pfTqiS04GxvXvjFN75uKGMUJbKszPCpT3qN556JefFeh/OmdnoHen9rjklG647vSeuOSUbgCCfY9wrH1HXD+6Fwrzs9AvPytQphlpKbj/4oH47UUDQ55Bqu9n9u+M4QW5ijn+Gf06YXTfjphww0i8d/tYlL84HhUTrsaMh893vcIIAMpfHI87zinEf341Lm5p/qCwEz6660xMu/9cxRxPKu9hBbm494IBmPiLM1D6l6s0+6O3fjYGZw/Ix6BuORg/sgdG9MoN6dsGyN6PhnbvgOyMVHTMSke79BTcemYfRXxXjyrAGf064adj+2CcWM+65GTiWnFck8byu88fEPE5rx/dC6f2zMVd5xVGDGuUcf07K65Jc5VnbFJMuRkjlkZnA3iWc36F+P0xAOCcvygLM0sMs5wxlgbgEICuAIrkYaVw4m26carhBUsjAAEzfYIgCIIgCIIgCIIgCKexYmm0GsBgxlh/xlgGBMfW08PCTAdwu/j/TQDmcUEbNR3ALeLpav0BDAawymCcnoUURgRBEARBEARBEARBuJ2I+1E45z7G2AMAZgFIBfA+53wrY+w5AGs459MBvAdgsujo+jgEJRDEcFMhOLj2Abifc94GAGpx2v94BEEQBEEQBEEQBEEQRDRE3J7mJryyPY0gCIIgCIIgCIIgCMItWNmeRhAEQRAEQRAEQRAEQSQZpDQiCIIgCIIgCIIgCIIgFJDSiCAIgiAIgiAIgiAIglBASiOCIAiCIAiCIAiCIAhCASmNCIIgCIIgCIIgCIIgCAWkNCIIgiAIgiAIgiAIgiAUkNKIIAiCIAiCIAiCIAiCUEBKI4IgCIIgCIIgCIIgCEIBKY0IgiAIgiAIgiAIgiAIBaQ0IgiCIAiCIAiCIAiCIBSQ0oggCIIgCIIgCIIgCIJQQEojgiAIgiAIgiAIgiAIQgEpjQiCIAiCIAiCIAiCIAgFpDQiCIIgCIIgCIIgCIIgFJDSiCAIgiAIgiAIgiAIglBASiOCIAiCIAiCIAiCIAhCASmNCIIgCIIgCIIgCIIgCAWkNCIIgiAIgiAIgiAIgiAUkNKIIAiCIAiCIAiCIAiCUEBKI4IgCIIgCIIgCIIgCEIB45w7nQfDMMaqAFQ6nQ8b6QLgqNOZIOICyTq5IHknDyTr5ILknVyQvJMHknVyQfJOLkjexunHOe8afjGhlEZegzG2hnM+1ul8ELGHZJ1ckLyTB5J1ckHyTi5I3skDyTq5IHknFyRv69D2NIIgCIIgCIIgCIIgCEIBKY0IgiAIgiAIgiAIgiAIBaQ0cpZ3nc4AETdI1skFyTt5IFknFyTv5ILknTyQrJMLkndyQfK2CPk0IgiCIAiCIAiCIAiCIBSQpRFBEARBEARBEARBEAShgJRGIoyxPoyx+Yyx7YyxrYyxh8XrnRljcxhjpeLfTuL1UxhjyxljzYyx34fF9TBjbIsYz+900rySMVbCGNvFGCuSXV/MGNsgfg4wxr7RuL8/Y2ylmLfPGWMZ4vXfMMY2i/cvYYwNt6OMvISX5C37/SbGGGeM0ekAYXhJ3oyxOxhjVbI47rGjjLyCl2Qt/nYzY2ybmIf/WC0fr+EleTPG/i67fydj7IQdZeQlPCbvvuKzrGeMbWKMjbejjLyCx2TdjzE2V5TzAsZYbzvKyEskqLwfEO/ljLEusuuMMfaG+NsmxtgYq+XjJTwma828eQ7OOX2ELXoFAMaI/3cAsBPAcAAvAygSrxcBeEn8vxuAHwD4C4Dfy+IZAWALgCwAaQC+BzBYJb1UALsBDACQAWAjgOEq4b4EcJtGnqcCuEX8fyKA+8T/c2VhfgzgO6fL120fL8lb9gyLAKwAMNbp8nXbx0vyBnAHgDedLlO3fjwm68EA1gPoJOXV6fJ128dL8g4L8yCA950uX7d9vCRvCD42pP+HA6hwunzd9PGYrP8L4Hbx/0sATHa6fN32SVB5jwZQCKACQBfZ9fEAZgJgAM4CsNLp8nXTx2OyVs2bFz9kaSTCOT/IOV8n/l8HYDuAXgCuBfCRGOwjANeJYY5wzlcDaA2LahiAFZzzRs65D8BCANerJHkmgF2c8zLOeQuAKWJaARhjHSAMLgqtJ2OMib99oZK3WlnQbADkuCoML8lb5HkInW1T5KdPPjwob0IDj8n6VwDe4pxXS3k1VAhJhMfkLedWAJ/pPHpS4jF5cwC54v95AA5ELIAkwmOyHg5grvj//PB4icSTt5iH9ZzzCpWfrgXwMRdYAaAjY6xAtwCSCC/JWidvnoOURiowxgohaBRXAujOOT8ICJUcgkZRjy0ALmCM5TPGsiBom/uohOsFYK/s+z7xmpzrAcwNUwJJ5AM4ITYSxf2MsfsZY7shKBIeipDnpCbR5c0YGw2gD+f82wh5JZD48ha5UTR5/oIxppY+AU/IegiAIYyxpYyxFYyxKyPkOanxgLyl5+gHoD+AeRHynNR4QN7PAvgFY2wfgBkQrMsIFTwg640AbpTF0YExlh8h30lLgshbDyNxE/CErJMGUhqFwRjLgWCe9rtoKg7nfDuAlwDMAfAdhIHCpxKUqd0e9l1vpVH3fs75W5zzgQD+BODJCNlOWhJd3oyxFAB/B/CooQwnOYkub/Hv/wAUcs5HQTDF/UglbNLjEVmnQdiidpEYxyTGWEfdjCcpHpG3xC0AvuCct2lmOMnxiLxvBfAh57w3hJedyeKYTsjwiKx/D+BCxth6ABcC2K+Rh6QngeSth5G4kx6PyDppoMFJBmMsHULl/ZRz/pV4+bBkUij+jbg9gHP+Hud8DOf8AgDHAZSKTr8kR1u/gaDllGtDe0NmmiyuQJwJoFh2bZZ4/yQARyGYO6ap3S9jCmhbiyoekXcHCHt6FzDGKiDsnZ7OyBm2Ao/IG5zzY5zzZvH6vwGcYa4kvI9XZC3GPY1z3so5LwdQAkGJRMjwkLwlbgFNXjXxkLzvhuADB5zz5QDaAQg4WCW8I2vO+QHO+Q2c89EAnhCv1ZguEI+TYPLWQzduwlOyThrSIgdJDhhjDMB7ALZzzl+T/TQdwO0AJoh/pxmIqxvn/AhjrC+AGwCczQWfFKfLwqQBGMwY6w9hxeEWAD+TRfMTAN9yzgM+ajjnV4SlMx/ATRAUQ4G8McYGc85LxWBXAygFEYJX5C1OOuRe/BdAcMS2JmIhJBFekbd4vUAy34Xg6H575BJIHrwkawh7628F8CETTusYAqAsYiEkER6TNxhjQwF0ArA88tMnHx6T9x4Al0Jo38MgKI2qIhZCkuAlWYv993HOuR/AYwDeN1QISUQiyluH6QAeYIxNATAOQI1s3pb0eEzWyQN3gTduN3wAnAfBVG0TgA3iZzyEPcpzIShe5gLoLIbvAUFzWQvghPh/rvjbYgDbIJjJXaqT5ngIHuN3A3gi7LcFAK6MkOcBAFYB2AXhZIZM8frrALaKzzAfwKlOl6/bPl6St0o8dHqah+UN4EWxfW8U2/cpTpevmz4ekzUD8JqYh80QT+WhjzflLf72LIAJTperWz9ekjcE58hLxfQ3APih0+Xrpo/HZH2TmN+dACZBZf6W7J8ElfdDYro+CJYrk8TrDMBbYrybQfNyL8taM29e+zDxgQmCIAiCIAiCIAiCIAgiAPk0IgiCIAiCIAiCIAiCIBSQ0oggCIIgCIIgCIIgCIJQQEojgiAIgiAIgiAIgiAIQgEpjQiCIAiCIAiCIAiCIAgFpDQiCIIgCIIgCIIgCIIgFJDSiCAIgiAIgiAIgiAIglBASiOCIAiCIAiCIAiCIAhCASmNCIIgCIIgCIIgCIIgCAX/D2dML4NLta2pAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1440x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "prom = prom_api.prometheus_connect.PrometheusConnect(url=prom_url, headers={\"Authorization\": \"bearer {}\".format(prom_token)}, \n",
+    "                                                 disable_ssl=True)\n",
+    "\n",
+    "metric_data = prom.get_metric_range_data(metric_name=metric_name,\n",
+    "                                     start_time=query_range[1],\n",
+    "                                     end_time=query_range[0],\n",
+    "                                     label_config=label_config)\n",
+    "\n",
+    "metrics = MetricsList(metric_data)\n",
+    "m = metrics[0]\n",
+    "\n",
+    "plt.figure(figsize=(20,10))\n",
+    "plt.plot(m.metric_values.ds, m.metric_values.y)\n",
+    "plt.plot(m.metric_values.ds, np.ones_like(m.metric_values.y)*0.007, c=\"red\")\n",
+    "plt.legend([\"metric_date\",\"threshold\"])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2019-07-09 23:47:00.825000048 training window end\n",
+      "2019-07-10 00:47:00.825000048 test window end\n",
+      "2019-07-09 23:47:00.825000048 training window end\n",
+      "2019-07-10 00:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 13\n",
+      "forecast anomalies 48\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 00:47:00.825000048 training window end\n",
+      "2019-07-10 01:47:00.825000048 test window end\n",
+      "2019-07-10 00:47:00.825000048 training window end\n",
+      "2019-07-10 01:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 8\n",
+      "forecast anomalies 47\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 01:47:00.825000048 training window end\n",
+      "2019-07-10 02:47:00.825000048 test window end\n",
+      "2019-07-10 01:47:00.825000048 training window end\n",
+      "2019-07-10 02:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 21\n",
+      "forecast anomalies 50\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 02:47:00.825000048 training window end\n",
+      "2019-07-10 03:47:00.825000048 test window end\n",
+      "2019-07-10 02:47:00.825000048 training window end\n",
+      "2019-07-10 03:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 33\n",
+      "forecast anomalies 53\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 03:47:00.825000048 training window end\n",
+      "2019-07-10 04:47:00.825000048 test window end\n",
+      "2019-07-10 03:47:00.825000048 training window end\n",
+      "2019-07-10 04:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 30\n",
+      "forecast anomalies 52\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 04:47:00.825000048 training window end\n",
+      "2019-07-10 05:47:00.825000048 test window end\n",
+      "2019-07-10 04:47:00.825000048 training window end\n",
+      "2019-07-10 05:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 29\n",
+      "forecast anomalies 44\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 05:47:00.825000048 training window end\n",
+      "2019-07-10 06:47:00.825000048 test window end\n",
+      "2019-07-10 05:47:00.825000048 training window end\n",
+      "2019-07-10 06:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 23\n",
+      "forecast anomalies 47\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 06:47:00.825000048 training window end\n",
+      "2019-07-10 07:47:00.825000048 test window end\n",
+      "2019-07-10 06:47:00.825000048 training window end\n",
+      "2019-07-10 07:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 31\n",
+      "forecast anomalies 46\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 07:47:00.825000048 training window end\n",
+      "2019-07-10 08:47:00.825000048 test window end\n",
+      "2019-07-10 07:47:00.825000048 training window end\n",
+      "2019-07-10 08:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 25\n",
+      "forecast anomalies 43\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 08:47:00.825000048 training window end\n",
+      "2019-07-10 09:47:00.825000048 test window end\n",
+      "2019-07-10 08:47:00.825000048 training window end\n",
+      "2019-07-10 09:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 16\n",
+      "forecast anomalies 34\n",
+      "number of data points 59\n",
+      "true positive rate 0.875\n",
+      "2019-07-10 09:47:00.825000048 training window end\n",
+      "2019-07-10 10:47:00.825000048 test window end\n",
+      "2019-07-10 09:47:00.825000048 training window end\n",
+      "2019-07-10 10:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 26\n",
+      "forecast anomalies 37\n",
+      "number of data points 59\n",
+      "true positive rate 0.8846153846153846\n",
+      "2019-07-10 10:47:00.825000048 training window end\n",
+      "2019-07-10 11:47:00.825000048 test window end\n",
+      "2019-07-10 10:47:00.825000048 training window end\n",
+      "2019-07-10 11:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 23\n",
+      "forecast anomalies 47\n",
+      "number of data points 59\n",
+      "true positive rate 0.8695652173913043\n",
+      "2019-07-10 11:47:00.825000048 training window end\n",
+      "2019-07-10 12:47:00.825000048 test window end\n",
+      "2019-07-10 11:47:00.825000048 training window end\n",
+      "2019-07-10 12:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 7\n",
+      "forecast anomalies 50\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 12:47:00.825000048 training window end\n",
+      "2019-07-10 13:47:00.825000048 test window end\n",
+      "2019-07-10 12:47:00.825000048 training window end\n",
+      "2019-07-10 13:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 13:47:00.825000048 training window end\n",
+      "2019-07-10 14:47:00.825000048 test window end\n",
+      "2019-07-10 13:47:00.825000048 training window end\n",
+      "2019-07-10 14:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 14:47:00.825000048 training window end\n",
+      "2019-07-10 15:47:00.825000048 test window end\n",
+      "2019-07-10 14:47:00.825000048 training window end\n",
+      "2019-07-10 15:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 15:47:00.825000048 training window end\n",
+      "2019-07-10 16:47:00.825000048 test window end\n",
+      "2019-07-10 15:47:00.825000048 training window end\n",
+      "2019-07-10 16:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 16:47:00.825000048 training window end\n",
+      "2019-07-10 17:47:00.825000048 test window end\n",
+      "2019-07-10 16:47:00.825000048 training window end\n",
+      "2019-07-10 17:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 17:47:00.825000048 training window end\n",
+      "2019-07-10 18:47:00.825000048 test window end\n",
+      "2019-07-10 17:47:00.825000048 training window end\n",
+      "2019-07-10 18:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 18:47:00.825000048 training window end\n",
+      "2019-07-10 19:47:00.825000048 test window end\n",
+      "2019-07-10 18:47:00.825000048 training window end\n",
+      "2019-07-10 19:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 19:47:00.825000048 training window end\n",
+      "2019-07-10 20:47:00.825000048 test window end\n",
+      "2019-07-10 19:47:00.825000048 training window end\n",
+      "2019-07-10 20:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 0\n",
+      "forecast anomalies 59\n",
+      "number of data points 59\n",
+      "true positive rate nan\n",
+      "2019-07-10 20:47:00.825000048 training window end\n",
+      "2019-07-10 21:47:00.825000048 test window end\n",
+      "2019-07-10 20:47:00.825000048 training window end\n",
+      "2019-07-10 21:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 8\n",
+      "forecast anomalies 52\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 21:47:00.825000048 training window end\n",
+      "2019-07-10 22:47:00.825000048 test window end\n",
+      "2019-07-10 21:47:00.825000048 training window end\n",
+      "2019-07-10 22:47:00.825000048 test window end\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:fbprophet.forecaster:Disabling yearly seasonality. Run prophet with yearly_seasonality=True to override this.\n",
+      "INFO:fbprophet.forecaster:Disabling weekly seasonality. Run prophet with weekly_seasonality=True to override this.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ground truth anomlies 31\n",
+      "forecast anomalies 44\n",
+      "number of data points 59\n",
+      "true positive rate 1.0\n",
+      "2019-07-10 22:47:00.825000048 training window end\n",
+      "2019-07-10 23:47:00.825000048 test window end\n",
+      "2019-07-10 22:47:00.825000048 training window end\n",
+      "2019-07-10 23:47:00.825000048 test window end\n",
+      "ground truth anomlies 36\n",
+      "forecast anomalies 40\n",
+      "number of data points 59\n",
+      "true positive rate 0.9166666666666666\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.9694444444444444"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "prometheus_anoamly_test(query_range, training_window, metric_name, label_config, prom_url, prom_token, threshold)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The overall true positive rate for this 24 hour period (between 2019-07-09 23:47:00 and 2019-07-10 23:47:00) was 0.97. Meaning that we correctly identified 97% of the anomalies present in the dataset. \n",
+    "\n",
+    "Of the known anomalies in our dataset, almost all were correctly identified. However, we can also see that this model, making forecasts on the anomalous 07/10 portion of the above time series(or the last eighth of our data), is skewed heavily towards over-reporting anomalies, and in many cases generated a relatively high false positive rate. In general, this is something that we will have to take into consideration, and future iterations of this test can include a false positive rate metric as well. \n",
+    "\n",
+    "That said, I think the above example shows that this test provides a good method for indicating how well a model is at identifying anomalies in simple prometheus metrics.  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Added a folder `notebooks` and one notebook that outlines a POC method for testing how well a model detects anomalies in prometheus metrics by simulating multiple training/ testing runs of a prophet model and evaluating the true positive rate.  