### PR TITLE
Fix environment.yml format

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,10 +7,10 @@ dependencies:
   - pip
   - fbprophet
   - pip:
-    - pandas
-    - apscheduler
-    - prometheus_client
-    - prometheus_api_client>=0.0.2b2
-    - tornado
-    - dateparser
-    - mlflow
+      - pandas
+      - apscheduler
+      - prometheus_client
+      - prometheus_api_client>=0.0.2b2
+      - tornado
+      - dateparser
+      - mlflow

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,16 @@
 ---
-- name: prophet-env
-  channels:
-    - conda-forge
-  dependencies:
-    - python=3.6
-    - pip
-    - fbprophet
-    - pip:
-        - pandas
-        - apscheduler
-        - prometheus_client
-        - prometheus_api_client>=0.0.2b2
-        - tornado
-        - dateparser
-        - mlflow
+name: prophet-env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - pip
+  - fbprophet
+  - pip:
+    - pandas
+    - apscheduler
+    - prometheus_client
+    - prometheus_api_client>=0.0.2b2
+    - tornado
+    - dateparser
+    - mlflow


### PR DESCRIPTION
As described in the [conda docs](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) the environment.yml file base structure should be a dict and not a list. It prevent building the Dockerfile which use "RUN conda env create -f /tmp/environment.yml"