### PR TITLE
Add Prometheus Service Discovery Annotations

### DIFF
--- a/openshift/oc-deployment-template.yaml
+++ b/openshift/oc-deployment-template.yaml
@@ -120,6 +120,9 @@ objects:
   - apiVersion: v1
     kind: Service
     metadata:
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
       name: ${APPLICATION_NAME}-service
       labels:
         app: ${APPLICATION_NAME}


### PR DESCRIPTION
This will make the service be scraped by prometheus automatically, so there won't be a need to change prometheus configs if automatic discovery of services is enabled

Edit:
This is enabled by default in Prometheus instances deployed by the [odh-operator](https://gitlab.com/opendatahub/opendatahub-operator/-/blob/master/roles/prometheus/templates/prometheus-objects.yaml.j2#L318)