### PR TITLE
added numpy in requirment.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas
+numpy
 schedule
 prometheus_client
 prometheus_api_client


### PR DESCRIPTION
numpy is required for Prophet lib, while running pip install -r requirement.txt if numpy is not available prophet installation will exit with  error