### PR TITLE
Update Dockerfile to use ubi8 python38 base image instead of miniconda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM continuumio/miniconda3
+FROM registry.access.redhat.com/ubi8/python-38:latest
 
-SHELL ["/bin/bash", "-c"]
-ADD . /
-RUN chmod +x set_uid.sh
-
-ADD environment.yml /tmp/environment.yml
-RUN chmod g+w /etc/passwd
-RUN conda env create -f /tmp/environment.yml
-
+# Add application sources to a directory that the assemble script expects them
+# and set permissions so that the container runs without root access
+USER 0
+ADD . /tmp/src
+RUN /usr/bin/fix-permissions /tmp/src
 USER 1001
 
-# Ensure that assigned uid has entry in /etc/passwd.
-CMD ./set_uid.sh && /opt/conda/envs/PAD/bin/python ${APP_FILE}
+# Install the dependencies
+RUN /usr/libexec/s2i/assemble
+
+# Set the default command for the resulting image
+CMD /usr/libexec/s2i/run


### PR DESCRIPTION
Resolves https://github.com/AICoE/prometheus-anomaly-detector/issues/153

The image built using updated dockerfile is available at `quay.io/aicoe/prometheus-anomaly-detector:ubi` to test